### PR TITLE
Replace as_device_scalar with cudf.Scalar.device_value

### DIFF
--- a/cpp/src/core/library.cpp
+++ b/cpp/src/core/library.cpp
@@ -43,13 +43,6 @@ class Mapper : public legate::mapping::Mapper {
   Mapper(const Mapper& rhs)            = delete;
   Mapper& operator=(const Mapper& rhs) = delete;
 
-  legate::mapping::TaskTarget task_target(
-    const legate::mapping::Task& task,
-    const std::vector<legate::mapping::TaskTarget>& options) override
-  {
-    return *options.begin();  // Choose first priority
-  }
-
   std::vector<legate::mapping::StoreMapping> store_mappings(
     const legate::mapping::Task& task,
     const std::vector<legate::mapping::StoreTarget>& options) override

--- a/python/legate_dataframe/lib/core/scalar.pyx
+++ b/python/legate_dataframe/lib/core/scalar.pyx
@@ -13,7 +13,6 @@ import numbers
 import cudf
 import legate.core
 import numpy
-from cudf._lib.scalar import as_device_scalar
 
 ScalarLike = numpy.number | numbers.Number | cudf.Scalar | legate.core.Scalar
 
@@ -39,5 +38,5 @@ cdef cpp_ScalarArg cpp_scalar_arg_from_python(scalar: ScalarLike):
 
     # NOTE: Converting to a cudf scalar isn't really ideal, as we copy
     #       to the device, just to copy it back again to get a legate one.
-    cdef DeviceScalar cudf_scalar = <DeviceScalar>as_device_scalar(scalar)
+    cdef DeviceScalar cudf_scalar = <DeviceScalar>(cudf.Scalar(scalar).device_value)
     return cpp_ScalarArg(dereference(cudf_scalar.get_raw_ptr()))


### PR DESCRIPTION
## Description
I'm slowly working on replacing cudf's `DeviceScalar` with pylibcudf's `Scalar` eventually. The first step is slimming down the old API so replacing `as_device_scalar` with an equivalent `cudf.Scalar.device_value` (which _should_ be API stable)

## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [ ] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
