### PR TITLE
MAINT: Quick fix for the one pool world

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 cpp/build/
+python/build/
 ci/manual-ci-test.py
 Docker
 python/_skbuild

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,9 +27,9 @@ RUN mkdir -p /opt/legate-dataframe/conda-env-file
 COPY ./conda/environments/*.yaml /opt/legate-dataframe/conda-env-file/
 
 # To ensure we find the GPU version of legate in the docker build.
-ARG CONDA_OVERRIDE_CUDA=$CUDA_VERSION
+ARG CONDA_OVERRIDE_CUDA=12.4
 RUN /bin/bash -c '/opt/conda/bin/mamba env create --name legate-dev --file \
-  /opt/legate-dataframe/conda-env-file/all_cuda-$(cut --output-delimiter="" -d "." -f 1,2 <<< ${CUDA_VERSION})_arch-x86_64.yaml'
+  /opt/legate-dataframe/conda-env-file/all_cuda-$(cut --output-delimiter="" -d "." -f 1,2 <<< ${CONDA_OVERRIDE_CUDA})_arch-x86_64.yaml'
 
 # Build and install legate-dataframe
 WORKDIR /opt/legate-dataframe

--- a/ci/manual-ci-test.py
+++ b/ci/manual-ci-test.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2024 NVIDIA Corporation
+# Copyright (c) 2024-2025, NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,11 +30,7 @@ commands = {
         "--no-capture-output",
         "-n",
         "legate-dev",
-        # TODO: Should not need legate startup,
-        # see https://github.com/nv-legate/legate.core.internal/issues/1304
-        "legate",
-        "--gpus=2",
-        "cpp/build/gtests/cpp_tests",
+        "ci/run_ctests.sh",
     ],
     "py": [
         "conda",
@@ -42,13 +38,7 @@ commands = {
         "--no-capture-output",
         "-n",
         "legate-dev",
-        # TODO: Should not need legate startup,
-        # see https://github.com/nv-legate/legate.core.internal/issues/1304
-        "legate",
-        "--gpus=2",
-        "--module",
-        "pytest",
-        "python/tests",
+        "ci/run_pytests.sh",
     ],
 }
 

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 # [description]
 #
@@ -26,6 +26,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/tests/
 LEGATE_TEST=${LEGATE_TEST:-1} \
 legate \
     --gpus "$(nvidia-smi -L | wc -l)"\
+    --fbmem=4000 \
     --module pytest \
     . \
     -sv \

--- a/cpp/src/core/repartition_by_hash.cu
+++ b/cpp/src/core/repartition_by_hash.cu
@@ -63,6 +63,7 @@ class ExchangedSizes {
     : _ctx(ctx), stream(ctx.tmp_stream())
   {
     assert(columns.size() == ctx.nranks - 1);
+    // Note: Size of this buffer is taken into account in the mapper:
     _all_sizes =
       legate::create_buffer<std::size_t>(ctx.nranks * ctx.nranks * 2, Memory::Kind::Z_COPY_MEM);
 
@@ -151,6 +152,7 @@ std::pair<std::vector<cudf::table_view>, std::map<int, rmm::device_buffer>> shuf
     std::size_t nbytes = sizes.metadata(peer, ctx.rank);
     if (nbytes > 0) {
       assert(peer != ctx.rank);
+      // Note: Size of this buffer is taken into account in the mapper:
       recv_metadata.insert(
         {peer, legate::create_buffer<uint8_t>(nbytes, Memory::Kind::Z_COPY_MEM)});
     }

--- a/cpp/tests/test_cudf_interop.cpp
+++ b/cpp/tests/test_cudf_interop.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,8 @@ namespace {
 static const char* library_name = "test.cudf_interop";
 
 struct RoundTripTableTask : public legate::LegateTask<RoundTripTableTask> {
-  static constexpr auto TASK_ID = legate::LocalTaskID{0};
+  static constexpr auto TASK_ID             = legate::LocalTaskID{0};
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
 
   static void gpu_variant(legate::TaskContext context)
   {

--- a/cpp/tests/test_repartition_by_hash.cpp
+++ b/cpp/tests/test_repartition_by_hash.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,8 @@ namespace {
 static const char* library_name = "test.repartition_by_hash";
 
 struct CheckHash : public legate::LegateTask<CheckHash> {
-  static constexpr auto TASK_ID = legate::LocalTaskID{0};
+  static constexpr auto TASK_ID             = legate::LocalTaskID{0};
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
 
   static void gpu_variant(legate::TaskContext context)
   {

--- a/cpp/tests/test_task.cpp
+++ b/cpp/tests/test_task.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,8 @@ namespace {
 static const char* library_name = "test.global_row_offset";
 
 struct GlobalRowOffsetTask : public legate::LegateTask<GlobalRowOffsetTask> {
-  static constexpr auto TASK_ID = legate::LocalTaskID{0};
+  static constexpr auto TASK_ID             = legate::LocalTaskID{0};
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
 
   static void gpu_variant(legate::TaskContext context)
   {
@@ -54,7 +55,8 @@ struct GlobalRowOffsetTask : public legate::LegateTask<GlobalRowOffsetTask> {
 };
 
 struct TaskArgumentMix : public legate::LegateTask<TaskArgumentMix> {
-  static constexpr auto TASK_ID = legate::LocalTaskID{1};
+  static constexpr auto TASK_ID             = legate::LocalTaskID{1};
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
 
   static void gpu_variant(legate::TaskContext context)
   {


### PR DESCRIPTION
This is just Wonchan's old PR with small comments added.  I plan to open an issue about actually adding at least some estimates about memory usage. This may not matter for many simple pipelines, but also could matter a lot for some.

(Memory use is not easy to bound, e.g. for joins or csv reading, although even a very high overestimate may be useful if we read a small csv for example.)