### PR TITLE
ENH: Support more return columns

### DIFF
--- a/cpp/src/core/library.cpp
+++ b/cpp/src/core/library.cpp
@@ -122,7 +122,8 @@ legate::Library create_and_registrate_library()
     GlobalMemoryResource::set_as_default_mmr_resource();
   }
   // Set with_has_allocations globally since currently all tasks allocate (and libcudf may also)
-  auto options = legate::VariantOptions{}.with_has_allocations(true);
+  // Also ensure we can generally work with 100+ return columns.
+  auto options = legate::VariantOptions{}.with_has_allocations(true).with_return_size(8192);
   auto context =
     legate::Runtime::get_runtime()->find_or_create_library(library_name,
                                                            legate::ResourceConfig{},

--- a/cpp/src/core/library.cpp
+++ b/cpp/src/core/library.cpp
@@ -122,8 +122,8 @@ legate::Library create_and_registrate_library()
     GlobalMemoryResource::set_as_default_mmr_resource();
   }
   // Set with_has_allocations globally since currently all tasks allocate (and libcudf may also)
-  // Also ensure we can generally work with 100+ return columns.
-  auto options = legate::VariantOptions{}.with_has_allocations(true).with_return_size(8192);
+  // Also ensure we can generally work with 2000+ return columns.
+  auto options = legate::VariantOptions{}.with_has_allocations(true).with_return_size(131072);
   auto context =
     legate::Runtime::get_runtime()->find_or_create_library(library_name,
                                                            legate::ResourceConfig{},

--- a/python/tests/test_csv.py
+++ b/python/tests/test_csv.py
@@ -60,10 +60,11 @@ def test_read_single_rows(tmp_path):
 
 def test_read_single_many_columns(tmp_path):
     # Legate has a limit on number of returns which limnits the
-    # number of columns (currently).  Make sure we support 100.
+    # number of columns (currently).  Make sure we support 1250.
+    # 2500+ are OK, but requires higher `--czmem`.
     file = tmp_path / "file.csv"
     # Write a file with many columns (and a few rows)
-    ncols = 120
+    ncols = 1250
     for i in range(5):
         file.write_text(",".join([str(i) for i in range(ncols)]) + "\n")
 

--- a/python/tests/test_csv.py
+++ b/python/tests/test_csv.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024, NVIDIA CORPORATION
+# Copyright (c) 2024-2025, NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -56,6 +56,18 @@ def test_read_single_rows(tmp_path):
     ddf.to_csv(filenames, index=False)
     tbl = csv_read(filenames, dtypes=df.dtypes)
     assert_frame_equal(tbl, df)
+
+
+def test_read_single_many_columns(tmp_path):
+    # Legate has a limit on number of returns which limnits the
+    # number of columns (currently).  Make sure we support 100.
+    file = tmp_path / "file.csv"
+    # Write a file with many columns (and a few rows)
+    ncols = 120
+    for i in range(5):
+        file.write_text(",".join([str(i) for i in range(ncols)]) + "\n")
+
+    csv_read(file, dtypes=["str"] * ncols)
 
 
 def test_read_many_files_per_rank(tmp_path):


### PR DESCRIPTION
Each column takes up some space in the return and this space is currently limited but settable.

This bumps the limit for all tasks so that we should be able to use well above 100 columns everywhere.

(Clearly, it is very plausible that we might bump this further if we run into a use-case that needs that.)

---

Tested just with csv, since that is where it came up (but if used, it tends to be the first call).  Either way, it should affect everything, so set it globally.