### PR TITLE
ENH: Add ``apply_boolean_mask``

### DIFF
--- a/cpp/include/legate_dataframe/core/library.hpp
+++ b/cpp/include/legate_dataframe/core/library.hpp
@@ -24,6 +24,7 @@ namespace task {
 
 namespace OpCode {
 enum : int {
+  ApplyBooleanMask,
   CSVWrite,
   CSVRead,
   ParquetWrite,

--- a/cpp/include/legate_dataframe/stream_compaction.hpp
+++ b/cpp/include/legate_dataframe/stream_compaction.hpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <legate_dataframe/core/column.hpp>
+#include <legate_dataframe/core/table.hpp>
+
+namespace legate::dataframe {
+
+/**
+ * @brief Filter a table busing a boolean mask.
+ *
+ * Select all rows from the table where the boolean mask column is true
+ * (non-null and not false).  The operation is stable.
+ *
+ * @param tbl The table to filter.
+ * @param boolean_mask The boolean mask to apply.
+ * @return The LogicalTable containing only the rows where the boolean_mask was true.
+ */
+LogicalTable apply_boolean_mask(const LogicalTable& tbl, const LogicalColumn& boolean_mask);
+
+}  // namespace legate::dataframe

--- a/cpp/src/core/library.cpp
+++ b/cpp/src/core/library.cpp
@@ -127,8 +127,8 @@ legate::Library create_and_registrate_library()
     GlobalMemoryResource::set_as_default_mmr_resource();
   }
   // Set with_has_allocations globally since currently all tasks allocate (and libcudf may also)
-  // Also ensure we can generally work with 2000+ return columns.
-  auto options = legate::VariantOptions{}.with_has_allocations(true).with_return_size(131072);
+  // Also ensure we can generally work with 1000+ non-string return columns.
+  auto options = legate::VariantOptions{}.with_has_allocations(true).with_return_size(32768);
   auto context =
     legate::Runtime::get_runtime()->find_or_create_library(library_name,
                                                            legate::ResourceConfig{},

--- a/cpp/src/stream_compaction.cpp
+++ b/cpp/src/stream_compaction.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/types.hpp>
+#include <legate.h>
+
+#include <cudf/stream_compaction.hpp>
+
+#include <legate_dataframe/core/column.hpp>
+#include <legate_dataframe/core/library.hpp>
+#include <legate_dataframe/core/table.hpp>
+#include <legate_dataframe/core/task_argument.hpp>
+#include <legate_dataframe/core/task_context.hpp>
+#include <stdexcept>
+
+namespace legate::dataframe {
+namespace task {
+
+class ApplyBooleanMaskTask : public Task<ApplyBooleanMaskTask, OpCode::ApplyBooleanMask> {
+ public:
+  static void gpu_variant(legate::TaskContext context)
+  {
+    GPUTaskContext ctx{context};
+    const auto tbl    = argument::get_next_input<PhysicalTable>(ctx);
+    auto boolean_mask = argument::get_next_input<PhysicalColumn>(ctx);
+    auto output       = argument::get_next_output<PhysicalTable>(ctx);
+
+    auto ret = cudf::apply_boolean_mask(
+      tbl.table_view(), boolean_mask.column_view(), ctx.stream(), ctx.mr());
+    output.move_into(std::move(ret));
+  }
+};
+
+}  // namespace task
+
+LogicalTable apply_boolean_mask(const LogicalTable& tbl, const LogicalColumn& boolean_mask)
+{
+  auto runtime = legate::Runtime::get_runtime();
+  auto ret     = LogicalTable::empty_like(tbl);
+
+  if (boolean_mask.cudf_type().id() != cudf::type_id::BOOL8) {
+    throw std::invalid_argument("boolean mask column must have a bool dtype.");
+  }
+
+  legate::AutoTask task = runtime->create_task(get_library(), task::ApplyBooleanMaskTask::TASK_ID);
+
+  argument::add_next_input(task, tbl);
+  argument::add_next_input(task, boolean_mask);
+  argument::add_next_output(task, ret);
+
+  runtime->submit(std::move(task));
+  return ret;
+}
+}  // namespace legate::dataframe
+
+namespace {
+
+void __attribute__((constructor)) register_tasks()
+{
+  legate::dataframe::task::ApplyBooleanMaskTask::register_variants();
+}
+
+}  // namespace

--- a/cpp/tests/test_stream_compaction.cpp
+++ b/cpp/tests/test_stream_compaction.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cudf/column/column_view.hpp>
+#include <cudf/stream_compaction.hpp>
+
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/table_utilities.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <legate_dataframe/stream_compaction.hpp>
+
+using namespace legate::dataframe;
+template <typename T>
+using column_wrapper = cudf::test::fixed_width_column_wrapper<T>;
+using strcol_wrapper = cudf::test::strings_column_wrapper;
+using CVector        = std::vector<std::unique_ptr<cudf::column>>;
+
+TEST(StreamCompactionTest, ApplyBooleanMask)
+{
+  column_wrapper<int32_t> col_0{{5, 4, 3, 1, 2, 0}};
+  strcol_wrapper col_1({"this", "is", "a", "string", "column", "!"});
+  column_wrapper<double> col_2{{0, 1, 2, 3, 4, 5}};
+
+  column_wrapper<bool> boolean_mask{{true, false, true, true, false, false}};
+
+  CVector cols;
+  cols.push_back(col_0.release());
+  cols.push_back(col_1.release());
+  cols.push_back(col_2.release());
+
+  cudf::table tbl(std::move(cols));
+
+  LogicalTable lg_tbl{tbl.view(), {"a", "b", "c"}};
+
+  auto expect = cudf::apply_boolean_mask(tbl, boolean_mask);
+  auto result = apply_boolean_mask(lg_tbl, LogicalColumn{boolean_mask});
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*expect, result.get_cudf()->view());
+
+  // Additionally, check that a null mask is honored by legate-dataframe
+  column_wrapper<bool> boolean_mask_nulls{{true, false, true, true, false, false},
+                                          {true, true, true, false, false, true}};
+
+  expect = cudf::apply_boolean_mask(tbl, boolean_mask_nulls);
+  result = apply_boolean_mask(lg_tbl, LogicalColumn{boolean_mask_nulls});
+  CUDF_TEST_EXPECT_TABLES_EQUIVALENT(*expect, result.get_cudf()->view());
+}

--- a/docs/source/api/table_funcs.rst
+++ b/docs/source/api/table_funcs.rst
@@ -2,6 +2,9 @@ Table functions
 ===============
 
 .. autofunction::
+    legate_dataframe.lib.stream_compaction.apply_boolean_mask
+
+.. autofunction::
     legate_dataframe.lib.groupby_aggregation.groupby_aggregation
 
 .. autofunction::

--- a/python/legate_dataframe/lib/CMakeLists.txt
+++ b/python/legate_dataframe/lib/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 # Set the list of Cython files to build
 set(cython_sources binaryop.pyx csv.pyx groupby_aggregation.pyx join.pyx parquet.pyx replace.pyx
-                   sort.pyx timestamps.pyx unaryop.pyx
+                   sort.pyx stream_compaction.pyx timestamps.pyx unaryop.pyx
 )
 
 rapids_cython_create_modules(

--- a/python/legate_dataframe/lib/stream_compacation.pyi
+++ b/python/legate_dataframe/lib/stream_compacation.pyi
@@ -1,0 +1,10 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from legate_dataframe import LogicalColumn, LogicalTable
+
+__all__ = ["apply_boolean_mask"]
+
+def apply_boolean_mask(
+    tbl: LogicalTable, boolean_mask: LogicalColumn
+) -> LogicalTable: ...

--- a/python/legate_dataframe/lib/stream_compaction.pyx
+++ b/python/legate_dataframe/lib/stream_compaction.pyx
@@ -38,7 +38,6 @@ def apply_boolean_mask(
     Returns
     -------
         The ``LogicalTable`` containing only the rows where the boolean_mask was true.
-
     """
     return LogicalTable.from_handle(
         cpp_apply_boolean_mask(tbl._handle, boolean_mask._handle))

--- a/python/legate_dataframe/lib/stream_compaction.pyx
+++ b/python/legate_dataframe/lib/stream_compaction.pyx
@@ -1,0 +1,44 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# distutils: language = c++
+# cython: language_level=3
+
+
+from legate_dataframe.lib.core.column cimport LogicalColumn, cpp_LogicalColumn
+from legate_dataframe.lib.core.table cimport LogicalTable, cpp_LogicalTable
+
+from legate_dataframe.utils import _track_provenance
+
+
+cdef extern from "<legate_dataframe/stream_compaction.hpp>" nogil:
+    cpp_LogicalTable cpp_apply_boolean_mask "legate::dataframe::apply_boolean_mask"(
+        const cpp_LogicalTable& tbl,
+        const cpp_LogicalColumn& boolean_mask,
+    ) except +
+
+
+@_track_provenance
+def apply_boolean_mask(
+    LogicalTable tbl,
+    LogicalColumn boolean_mask,
+):
+    """Filter a table busing a boolean mask.
+
+    Select all rows from the table where the boolean mask column is true
+    (non-null and not false).  The operation is stable.
+
+    Parameters
+    ----------
+    tbl
+        The table to filter.
+    boolean_mask
+        The boolean mask to apply.
+
+    Returns
+    -------
+        The ``LogicalTable`` containing only the rows where the boolean_mask was true.
+
+    """
+    return LogicalTable.from_handle(
+        cpp_apply_boolean_mask(tbl._handle, boolean_mask._handle))

--- a/python/tests/test_csv.py
+++ b/python/tests/test_csv.py
@@ -60,15 +60,16 @@ def test_read_single_rows(tmp_path):
 
 def test_read_single_many_columns(tmp_path):
     # Legate has a limit on number of returns which limnits the
-    # number of columns (currently).  Make sure we support 1250.
-    # 2500+ are OK, but requires higher `--czmem`.
+    # number of columns (currently).  Make sure we support ~1000.
+    # As of legate 25.01 increasing this further requires increasing zcmem,
+    # future versions are likely to fix both issues.
     file = tmp_path / "file.csv"
     # Write a file with many columns (and a few rows)
-    ncols = 1250
+    ncols = 1000
     for i in range(5):
         file.write_text(",".join([str(i) for i in range(ncols)]) + "\n")
 
-    csv_read(file, dtypes=["str"] * ncols)
+    csv_read(file, dtypes=["int64"] * ncols)
 
 
 def test_read_many_files_per_rank(tmp_path):

--- a/python/tests/test_stream_compaction.py
+++ b/python/tests/test_stream_compaction.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2025, NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import cudf
+import cupy
+import pytest
+
+from legate_dataframe import LogicalColumn, LogicalTable
+from legate_dataframe.lib.stream_compaction import apply_boolean_mask
+from legate_dataframe.testing import assert_frame_equal, std_dataframe_set
+
+
+@pytest.mark.parametrize("cudf_df", std_dataframe_set())
+def test_apply_boolean_mask_basic(cudf_df: cudf.DataFrame):
+    lg_df = LogicalTable.from_cudf(cudf_df)
+
+    cupy.random.seed(0)
+    cudf_mask = cudf.Series(cupy.random.randint(0, 2, size=len(cudf_df)), dtype=bool)
+    lg_mask = LogicalColumn.from_cudf(cudf_mask._column)
+
+    res = apply_boolean_mask(lg_df, lg_mask)
+    expect = cudf_df[cudf_mask]
+
+    assert_frame_equal(res, expect)
+
+
+@pytest.mark.parametrize("cudf_df", std_dataframe_set())
+def test_apply_boolean_mask_nulls(cudf_df: cudf.DataFrame):
+    # Similar to `test_apply_boolean_mask`, but cover a nullable column
+    lg_df = LogicalTable.from_cudf(cudf_df)
+
+    cupy.random.seed(0)
+    mask_values = cupy.random.randint(0, 2, size=len(cudf_df)).astype(bool)
+    mask_mask = cupy.random.randint(0, 2, size=len(cudf_df)).astype(bool)
+    cudf_mask = cudf.Series(mask_values)
+    cudf_mask = cudf_mask.mask(mask_mask)
+    lg_mask = LogicalColumn.from_cudf(cudf_mask._column)
+
+    res = apply_boolean_mask(lg_df, lg_mask)
+    expect = cudf_df[cudf_mask]
+
+    assert_frame_equal(res, expect)
+
+
+@pytest.mark.parametrize(
+    "bad_mask",
+    [
+        cudf.Series([1, 2, 3, 4]),  # not boolean
+        # wrong length, but as of writing not caught before at/task launch:
+        pytest.param(
+            cudf.Series([True, False, False, True, False]), marks=pytest.mark.skip
+        ),
+    ],
+)
+def test_apply_boolean_mask_errors(bad_mask):
+    df = cudf.DataFrame({"a": [1, 2, 3, 4]})
+
+    lg_df = LogicalTable.from_cudf(df)
+    bad_mask = LogicalColumn.from_cudf(bad_mask._column)
+
+    with pytest.raises(ValueError):
+        apply_boolean_mask(lg_df, bad_mask)

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -38,7 +38,7 @@ def test_python_launched_tasks():
 
     # Then, we can create the task and provide the task arguments using the
     # exact same order as in the task implementation ("unaryop.cpp").
-    task = runtime.create_auto_task(lib, 5)  # TODO: get the enum of `UnaryOperator`
+    task = runtime.create_auto_task(lib, 6)  # TODO: get the enum of `UnaryOperator`
     task.add_scalar_arg(UnaryOperator.ABS.value, dtype=lg_type.int32)
     col.add_as_next_task_input(task)
     result = LogicalColumn.empty_like_logical_column(col)


### PR DESCRIPTION
Adding it with a similar file structure to libcudf which uses
``stream_compaction``.  (Not sure about the names, but also good to
keep aligned with libcudf.)

Straight forward exposure of the table-wise boolean masking.

---

Other fixup is due to sorting tests running into issues with the high column things now, so lowered it.
(It must be unrelated, but the `test_task.py` seemed to hang when run as an individual test.)