### PR TITLE
BLD: Ensure we fetch the `_gpu` tag version

### DIFF
--- a/conda/recipes/legate-dataframe/meta.yaml
+++ b/conda/recipes/legate-dataframe/meta.yaml
@@ -55,7 +55,7 @@ requirements:
     # the '<=12.6.0' can be removed once this is resolved:
     # https://github.com/conda-forge/cuda-python-feedstock/issues/95
     - cuda-python >=12.0,<13.0a0,<=12.6.0
-    - legate {{ legate_version }}
+    - legate {{ legate_version }} =*_gpu*
     # Only to ensure a nightly legate version we pick up
     # is compatible with an existing cupynumeric version.
     # (may also stabilize not using debug/sanitizer builds)


### PR DESCRIPTION
I am not sure if this should also be included in the dependencies.yaml, but I suppose it shouldn't matter too much there for a release at least. (conda didn't seem to like just adding it?)

This is identical to legate-boost (which needs to pick cpu or gpu depending on the build).