### PR TITLE
BLD: Fix split recipe dependencies [skip ci]

### DIFF
--- a/conda/recipes/legate-dataframe/meta.yaml
+++ b/conda/recipes/legate-dataframe/meta.yaml
@@ -72,10 +72,14 @@ outputs:
     string: "cuda{{ cuda_major }}_py{{ py_version }}_{{ PKG_BUILDNUM }}"
     script: install_legate-dataframe.sh
     requirements:
-      # Note: cuda-version and legate (+cupynumeric) are here for their run-exports
+      # Note: build/host exists for run-exports (except cmake, pip, and python)
+      # for librmm, libcudf, pylibcudf we rely on the rmm/cudf run dependency.
       build:
         - cmake {{ cmake_version }}
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
         - cuda-version ={{ cuda_version }}
+        - {{ stdlib("c") }}
       host:
         - cuda-version ={{ cuda_version }}
         - legate {{ legate_version }} =*_gpu*

--- a/conda/recipes/legate-dataframe/meta.yaml
+++ b/conda/recipes/legate-dataframe/meta.yaml
@@ -34,11 +34,6 @@ build:
     - SCCACHE_S3_KEY_PREFIX=legate-dataframe-linux64 # [linux64]
     - SCCACHE_S3_USE_SSL
     - SCCACHE_S3_NO_CREDENTIALS
-  ignore_run_exports_from:
-    - {{ compiler('cuda') }}
-    - cuda-python
-    - cuda-cudart-dev
-    - cupynumeric  # only a build dependency to help resolver
 
 requirements:
   build:
@@ -77,10 +72,14 @@ outputs:
     string: "cuda{{ cuda_major }}_py{{ py_version }}_{{ PKG_BUILDNUM }}"
     script: install_legate-dataframe.sh
     requirements:
+      # Note: cuda-version and legate (+cupynumeric) are here for their run-exports
       build:
         - cmake {{ cmake_version }}
+        - cuda-version ={{ cuda_version }}
       host:
         - cuda-version ={{ cuda_version }}
+        - legate {{ legate_version }} =*_gpu*
+        - cupynumeric {{ cupynumeric_version }}
         - python
         - pip
       run:
@@ -98,6 +97,8 @@ outputs:
         - numpy >=1.23,<3.0.0a0
         - rmm {{ rapids_version }}
         - cudf {{ rapids_version }}
+    ignore_run_exports_from:
+      - cupynumeric  # only a build dependency to help resolver
     run_exports:
       - {{ pin_subpackage("legate-dataframe", max_pin="x.x") }}
     test:


### PR DESCRIPTION
Run-exports is only picked up from the current build step (which makes sense, since they can differ), but this means that we need to manually include anything that we want to pick up in the host/build section (i.e. mostly legate).

Since cudf/rmm already depend on pylibcudf, libcudf, and librmm, I have not duplicated these.

**Do not merge until version upload is clarified.**