### PR TITLE
ENH: Support `names=` in csv reading to not provide a header

### DIFF
--- a/conda/environments/all_cuda-124_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-124_arch-x86_64.yaml
@@ -39,7 +39,7 @@ dependencies:
 - python>=3.10,<3.13
 - rapids-build-backend>=0.3.2,<0.4.0.dev0
 - scikit-build-core>=0.10.0
-- sphinx>=8.0
+- sphinx>=8.0,!=8.2.0
 - sysroot_linux-64==2.17
 - valgrind
 name: all_cuda-124_arch-x86_64

--- a/cpp/include/legate_dataframe/csv.hpp
+++ b/cpp/include/legate_dataframe/csv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,21 +56,24 @@ void csv_write(LogicalTable& tbl, const std::string& dirpath, char delimiter = '
  *
  * Note that file order is currently glob/string sorted.
  *
- * TODO: This function does currently not support passing csv reader
- *       parameters.
+ * TODO: We should replace some/all params with cudf::io::csv_reader_options eventually.
+ *       As if writing, this would be better with pylibcudf 25.02 which cannot be quite used.
  *
  * @param glob_string The glob string to specify the csv files. All glob matches must be valid
  * csv files and have the same layout. See <https://linux.die.net/man/7/glob>.
  * @param dtypes The cudf type for each column (must match usecols).
  * @param na_filter Whether to detect missing values, set to false to improve performance.
  * @param delimiter The field delimiter.
- * @param usecols The column names to read from the file, if not passed reads all columns.
+ * @param names The column names to read from the file, if not passed reads all columns.
+ * @param usecols Column index in file.  If given, assumes the file includes no header.
+ * passing `usecols_idx` without names is not supported.
  * @return The read LogicalTable.
  */
 LogicalTable csv_read(const std::string& glob_string,
                       const std::vector<cudf::data_type>& dtypes,
-                      bool na_filter                                         = true,
-                      char delimiter                                         = ',',
-                      const std::optional<std::vector<std::string>>& usecols = std::nullopt);
+                      bool na_filter                                       = true,
+                      char delimiter                                       = ',',
+                      const std::optional<std::vector<std::string>>& names = std::nullopt,
+                      const std::optional<std::vector<int>>& usecols       = std::nullopt);
 
 }  // namespace legate::dataframe

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -158,7 +158,7 @@ dependencies:
         packages:
           - myst-parser>=4.0
           - pydata-sphinx-theme>=0.16.0
-          - sphinx>=8.0
+          - sphinx>=8.0,!=8.2.0
       - output_types: [conda]
         packages:
           - make

--- a/python/legate_dataframe/lib/csv.pyi
+++ b/python/legate_dataframe/lib/csv.pyi
@@ -14,5 +14,6 @@ def csv_read(
     *,
     na_filter: bool = False,
     delimiter: str = ",",
-    usecols: Iterable[str] | None,
+    usecols: Iterable[str | int] | None,
+    names: Iterable[str] | None,
 ) -> LogicalTable: ...


### PR DESCRIPTION
We still don't allow usecols just being indices (we could).

In general, I would like to move to use csv_options at some point (even if we have to copy out the ones we can deal with), but that might take a bit and it seemed that this is a bit of a pain point.

TBH, I am a bit confused about the need for sorting, but it seems I also was confused about it previously (i.e. further down there is another sort).