### PR TITLE
require sphinx<8.2.0

### DIFF
--- a/conda/environments/all_cuda-124_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-124_arch-x86_64.yaml
@@ -39,7 +39,7 @@ dependencies:
 - python>=3.10,<3.13
 - rapids-build-backend>=0.3.2,<0.4.0.dev0
 - scikit-build-core>=0.10.0
-- sphinx>=8.0,!=8.2.0
+- sphinx>=8.0,<8.2.0
 - sysroot_linux-64==2.17
 - valgrind
 name: all_cuda-124_arch-x86_64

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -158,7 +158,8 @@ dependencies:
         packages:
           - myst-parser>=4.0
           - pydata-sphinx-theme>=0.16.0
-          - sphinx>=8.0,!=8.2.0
+          # the ceiling on sphinx can be removed when https://github.com/spatialaudio/nbsphinx/issues/825 is resolved
+          - sphinx>=8.0,<8.2.0
       - output_types: [conda]
         packages:
           - make


### PR DESCRIPTION
## Description

A pin like `sphinx!=8.2.0` was added in #30, I'm guessing for similar reasons as documented in  https://github.com/rapidsai/build-planning/issues/155.

That can't be removed until some upstream changes are made in `nbsphinx` (linked in that issue). This proposes changing the pin to `<8.2.0` (to prevent CI breaking again if an 8.2.1 or 8.3.0 is released) and adding a comment explaining when it can be removed.

## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [x] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
