### PR TITLE
ENH: Implement basic reductions

### DIFF
--- a/cpp/include/legate_dataframe/core/library.hpp
+++ b/cpp/include/legate_dataframe/core/library.hpp
@@ -37,6 +37,7 @@ enum : int {
   Join,
   ToTimestamps,
   ExtractTimestampComponent,
+  ReduceLocal,
   Sequence,
   Sort,
   GroupByAggregation

--- a/cpp/include/legate_dataframe/reduction.hpp
+++ b/cpp/include/legate_dataframe/reduction.hpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <legate.h>
+
+#include <cudf/aggregation.hpp>
+
+#include <legate_dataframe/core/column.hpp>
+
+namespace legate::dataframe {
+
+/**
+ * @brief Reduce a column given a libcudf reduction.
+ *
+ * @param col Logical column to reduce
+ * @param agg The reduction to perform
+ * @param output_dtype The output cudf dtype.
+ * @param initial Optional initial scalar (column) only supported for numeric types.
+ * @returns A LogicalColumn marked as scalar.
+ */
+LogicalColumn reduce(
+  const LogicalColumn& col,
+  const cudf::reduce_aggregation& agg,
+  cudf::data_type output_dtype,
+  std::optional<std::reference_wrapper<const LogicalColumn>> initial = std::nullopt);
+
+}  // namespace legate::dataframe

--- a/cpp/src/reduction.cpp
+++ b/cpp/src/reduction.cpp
@@ -118,9 +118,7 @@ class ReduceLocalTask : public Task<ReduceLocalTask, OpCode::ReduceLocal> {
 
     // Note: cudf has no helper to go to a column view right now, but we could
     // specialize this in principle.
-    auto ret = cudf::make_column_from_scalar(*scalar_res, 1, ctx.stream(), ctx.mr());
-
-    output.move_into(std::move(ret));
+    output.move_into(cudf::make_column_from_scalar(*scalar_res, 1, ctx.stream(), ctx.mr()));
   }
 };
 
@@ -386,7 +384,6 @@ class AggregationHelper final {
       }
       default: {
         auto first_pass_res = get_first_pass_result(agg, output_type);
-        // TODO: Use initial here (we may need it, e.g. for sums).
         return perform_simple_reduce(
           first_pass_res, agg.kind, /* finalize */ true, output_type, initial);
       }

--- a/cpp/src/reduction.cpp
+++ b/cpp/src/reduction.cpp
@@ -1,0 +1,433 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <numeric>
+#include <optional>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <vector>
+
+#include <legate.h>
+
+#include <cudf/aggregation.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/detail/aggregation/aggregation.hpp>  // cudf::detail::target_type
+#include <cudf/groupby.hpp>
+#include <cudf/reduction.hpp>
+#include <cudf/types.hpp>
+
+#include <legate_dataframe/binaryop.hpp>
+#include <legate_dataframe/core/library.hpp>
+#include <legate_dataframe/reduction.hpp>
+
+namespace legate::dataframe {
+namespace task {
+
+namespace {
+
+/*
+ * Helper just to get back from aggregation kind to actual aggregation object.
+ */
+std::unique_ptr<cudf::reduce_aggregation> make_reduce_aggregation(cudf::aggregation::Kind kind)
+{
+  switch (kind) {
+    case cudf::aggregation::Kind::SUM: {
+      return cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+    }
+    case cudf::aggregation::Kind::PRODUCT: {
+      return cudf::make_product_aggregation<cudf::reduce_aggregation>();
+    }
+    case cudf::aggregation::Kind::MIN: {
+      return cudf::make_min_aggregation<cudf::reduce_aggregation>();
+    }
+    case cudf::aggregation::Kind::MAX: {
+      return cudf::make_max_aggregation<cudf::reduce_aggregation>();
+    }
+    case cudf::aggregation::Kind::SUM_OF_SQUARES: {
+      return cudf::make_sum_of_squares_aggregation<cudf::reduce_aggregation>();
+    }
+    case cudf::aggregation::Kind::MEAN: {
+      return cudf::make_mean_aggregation<cudf::reduce_aggregation>();
+    }
+    default: {
+      throw std::invalid_argument("Missing reduce aggregation mapping.");
+    }
+  }
+}
+
+}  // namespace
+
+class ReduceLocalTask : public Task<ReduceLocalTask, OpCode::ReduceLocal> {
+ public:
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
+
+  static void gpu_variant(legate::TaskContext context)
+  {
+    GPUTaskContext ctx{context};
+
+    const auto input = argument::get_next_input<PhysicalColumn>(ctx);
+    auto agg_kind    = argument::get_next_scalar<cudf::aggregation::Kind>(ctx);
+    auto finalize    = argument::get_next_scalar<bool>(ctx);
+    auto initial     = argument::get_next_scalar<bool>(ctx);
+    auto output      = argument::get_next_output<PhysicalColumn>(ctx);
+    // Fetching initial value column below if used.
+
+    auto col_view = input.column_view();
+    std::unique_ptr<const cudf::scalar> scalar_res;
+    // TODO: Counting is slightly awkward, it may be best if it was just
+    // specially handled (once we have a count-valid function)
+    if (agg_kind == cudf::aggregation::Kind::COUNT_VALID) {
+      assert(!initial);
+      if (!finalize) {
+        auto count = col_view.size() - col_view.null_count();
+        scalar_res =
+          std::make_unique<cudf::scalar_type_t<int64_t>>(count, true, ctx.stream(), ctx.mr());
+      } else {
+        auto sum   = cudf::make_sum_aggregation<cudf::reduce_aggregation>();
+        auto zero  = cudf::numeric_scalar<int64_t>(0, true, ctx.stream(), ctx.mr());
+        scalar_res = cudf::reduce(col_view, *sum, output.cudf_type(), zero, ctx.stream(), ctx.mr());
+      }
+    } else {
+      auto agg = make_reduce_aggregation(agg_kind);
+      if (initial) {
+        auto initial_col    = argument::get_next_input<PhysicalColumn>(ctx);
+        auto initial_scalar = initial_col.cudf_scalar();
+        scalar_res =
+          cudf::reduce(col_view, *agg, output.cudf_type(), *initial_scalar, ctx.stream(), ctx.mr());
+      } else {
+        scalar_res = cudf::reduce(col_view, *agg, output.cudf_type(), ctx.stream(), ctx.mr());
+      }
+    }
+
+    // Note: cudf has no helper to go to a column view right now, but we could
+    // specialize this in principle.
+    auto ret = cudf::make_column_from_scalar(*scalar_res, 1, ctx.stream(), ctx.mr());
+
+    output.move_into(std::move(ret));
+  }
+};
+
+}  // namespace task
+
+namespace {
+
+/* Reductions that never need a nullable column */
+const std::set<cudf::aggregation::Kind> NEVER_NULL = {
+  cudf::aggregation::Kind::COUNT_VALID,
+  cudf::aggregation::Kind::ANY,
+  cudf::aggregation::Kind::ALL,
+};
+
+/*
+ * Perform a simple reduction.
+ *
+ * The caller must indicate whether this is a first-pass or second-pass
+ * (finalizing) reduction.  And the caller must ensure that the aggregation
+ * is sensible.
+ *
+ * @param col The column/values to reduce.
+ * @param kind The aggregation kind (only supports simple aggs!).
+ * @param finalize boolean to indicate which step we are in.  If false,
+ * this is a first pass simple reduction, if true it is a finalizing one.
+ * @param output_type The desired result dtype.
+ * @param initial The (user requested) initial result.  Only useful if finalizing.
+ * @return A logical column containing the result.  If finalize is false this
+ * has one entry per partition.  If true, will contain a single entry.
+ */
+LogicalColumn perform_simple_reduce(
+  const LogicalColumn& col,
+  cudf::aggregation::Kind kind,
+  bool finalize,
+  const cudf::data_type& output_type,
+  std::optional<std::reference_wrapper<const LogicalColumn>> initial = std::nullopt)
+{
+  auto runtime = legate::Runtime::get_runtime();
+
+  // with identity, result is never null (might be type dependent eventually).
+  auto nullable = NEVER_NULL.count(kind) == 0;
+  if (nullable && initial.has_value()) {
+    const LogicalColumn& initial_col = initial.value();
+    nullable                         = initial_col.nullable();
+  }
+  auto ret = LogicalColumn::empty_like(output_type, nullable, /* scalar */ finalize);
+
+  legate::AutoTask task = runtime->create_task(get_library(), task::ReduceLocalTask::TASK_ID);
+
+  // If we "finalize", gather all data to one worker via a broadcast constraint
+  auto var = argument::add_next_input(task, col, /* broadcast */ finalize);
+  argument::add_next_scalar(task,
+                            static_cast<std::underlying_type_t<cudf::aggregation::Kind>>(kind));
+  argument::add_next_scalar(task, finalize);
+  argument::add_next_scalar(task, initial.has_value());
+  argument::add_next_output(task, ret);
+  if (initial.has_value()) {
+    if (!finalize) {
+      // If there is a use case in the future, simply remove this check.
+      throw std::logic_error("initial doesn't make sense when not finalizing");
+    }
+    argument::add_next_input(task, initial.value(), true);
+  }
+
+  runtime->submit(std::move(task));
+  return ret;
+}
+
+/*
+ * Aggregations that can be implemented via `reduce -> gather -> reduce`, i.e.
+ * they are associative.  `count` technically requires `count -> gather -> sum`
+ * but we encode this on the task side (the second SUM also needs a zero initial).
+ */
+const std::set<cudf::aggregation::Kind> SIMPLE_AGGS = {
+  cudf::aggregation::Kind::ANY,
+  cudf::aggregation::Kind::ALL,
+  cudf::aggregation::Kind::MIN,
+  cudf::aggregation::Kind::MAX,
+  cudf::aggregation::Kind::PRODUCT,
+  cudf::aggregation::Kind::SUM,
+  cudf::aggregation::Kind::COUNT_VALID,
+  // Sum of squares should likely be two pass (run after subtracting mean):
+  // cudf::aggregation::Kind::SUM_OF_SQUARES,
+};
+
+/*
+ * Fully describe any aggregation and how to compare/hash them.
+ * (If we use this for groupby, we would add the column name to this.)
+ */
+class AggregationDescriptor final {
+ public:
+  /*
+   * Create an aggregation descriptor form an agg, output_type and optional
+   * initial.  Note that the initial value is a pointer and thus not owned.
+   * (As of now initial is always user provided here, so this is easy.)
+   */
+  AggregationDescriptor(const cudf::aggregation& agg,
+                        cudf::data_type& output_type,
+                        std::optional<std::reference_wrapper<const LogicalColumn>> initial)
+    : agg{agg.clone()}, output_type{output_type}, initial_{initial} {};
+
+  AggregationDescriptor(const AggregationDescriptor& other)
+    : agg{other.agg->clone()}, output_type{other.output_type}, initial_{other.initial_} {};
+
+  std::size_t do_hash() const
+  {
+    // Don't be fancy, so just xor the hash of the components
+    return (agg->do_hash() ^ static_cast<std::size_t>(output_type.id()) ^ output_type.scale() ^
+            (initial_.has_value() ? reinterpret_cast<std::size_t>(&initial_.value().get()) : 0));
+  };
+
+  bool operator==(const AggregationDescriptor& other) const
+  {
+    // TODO(seberg): The dtype equality should be fine right now, but it is not
+    // strictly correct for complicated dtypes (structs, lists).
+    assert(output_type.id() != cudf::type_id::STRUCT && output_type_id() != cudf::type_id::LIST);
+    return (agg->is_equal(*other.agg) && output_type.id() == other.output_type.id() &&
+            output_type.scale() == other.output_type.scale() &&
+            initial_.has_value() == other.initial_.has_value() &&
+            (!initial_.has_value() || &initial_.value().get() == &other.initial_.value().get()));
+  };
+
+  std::unique_ptr<const cudf::aggregation> agg;
+  const cudf::data_type output_type;
+
+ private:
+  std::optional<std::reference_wrapper<const LogicalColumn>> initial_;
+};
+
+struct hash_agg_descr {
+  size_t operator()(const AggregationDescriptor& agg_descr) const { return agg_descr.do_hash(); }
+};
+
+/*
+ * To do distributed aggregations we need to split them into first pass
+ * aggregations that are calculated locally, but are not final and result
+ * aggregations which make use of those results.
+ * Additionally, some aggregations may be composites of others, such as mean
+ * which is `sum/count`, while others like argmin/argmax would need a custom
+ * finalization.
+ *
+ * (This helper is slightly overpowered, as it supports doing multiple
+ * aggregations on the same column at once, however, that could be helpful.
+ * It also designed in a way that it should be possible to specialize it for
+ * other aggregations, such as group-by)
+ */
+class AggregationHelper final {
+ public:
+  AggregationHelper(const LogicalColumn& col) : col_{col} {}
+
+  /*
+   * Add a reduction request.  This will be broken down to individual reductions.
+   *
+   * WARNING: the `initial` value must outlive the `AggregationHelper` and its
+   * pointer identity is used as a unique identifier.
+   */
+  void add(const cudf::aggregation& agg,
+           cudf::data_type& output_type,
+           std::optional<std::reference_wrapper<const LogicalColumn>> initial)
+  {
+    AggregationDescriptor agg_descr{agg, output_type, initial};
+    if (results_.count(agg_descr)) { return; }
+
+    breakdown_aggregation(agg, output_type);
+    results_.try_emplace(agg_descr, std::nullopt);
+  }
+
+  /*
+   * Helper to add a first pass request.  For now we assume that these never
+   * need initial values, if they do we'll have to take care about ownership
+   * (i.e. improve the way we compare the initial value).
+   */
+  void add_first_pass(const cudf::aggregation& agg, cudf::data_type output_type)
+  {
+    AggregationDescriptor agg_descr{agg, output_type, std::nullopt};
+    first_pass_results_.try_emplace(agg_descr, std::nullopt);
+  }
+
+  LogicalColumn get_result(const cudf::aggregation& agg,
+                           cudf::data_type& output_type,
+                           std::optional<std::reference_wrapper<const LogicalColumn>> initial)
+  {
+    AggregationDescriptor agg_descr{agg, output_type, initial};
+
+    auto res = results_.at(agg_descr);
+    if (res.has_value()) { return res.value(); }
+
+    LogicalColumn result = calculate_aggregation(agg, output_type, initial);
+    results_[agg_descr]  = result;
+    return result;
+  }
+
+  LogicalColumn get_first_pass_result(const cudf::aggregation& agg, cudf::data_type& output_type)
+  {
+    AggregationDescriptor agg_descr{agg, output_type, std::nullopt};
+    return first_pass_results_.at(agg_descr).value();
+  }
+
+  /*
+   * Note that the following functions are designed so that they can (hopefully)
+   * be split out and re-used e.g. to improve groupby-aggregations.
+   * (Doing this would require e.g. threading in column indices that would be
+   * always 0 for the purposes here.)
+   */
+
+  /*
+   * Function to find the breakdown aggregations needed to finalize this one.
+   * That is, breakdown_aggregation is designed to be overloadable in theory
+   * and uses `add` or `add_first_pass` to add any full or first path aggs
+   * needed to do it's own finalization.
+   */
+  void breakdown_aggregation(const cudf::aggregation& agg, cudf::data_type& output_type)
+  {
+    switch (agg.kind) {
+      case cudf::aggregation::Kind::MEAN: {
+        /* Mean calculates it's final result from the final sum and counts. */
+        add(*cudf::make_sum_aggregation(), output_type, std::nullopt);
+        auto cudf_int64 = cudf::data_type{cudf::type_id::INT64};
+        add(*cudf::make_count_aggregation(), cudf_int64, std::nullopt);
+        break;
+      }
+      default: {
+        if (SIMPLE_AGGS.count(agg.kind) == 0) {
+          throw std::invalid_argument("Aggregation kind is currently not supported:" +
+                                      std::to_string(agg.kind));
+        }
+        add_first_pass(agg, output_type);
+      }
+    }
+  }
+
+  /*
+   * Launch all first pass calculations (must be called before getting final results).
+   *
+   * Note: If we add argmax, it's task would also calculate the max and we should
+   * prioritize it over a `max` launch here (i.e. there may be optimization left to do).
+   */
+  void do_first_pass()
+  {
+    for (auto& [agg_descr, col] : first_pass_results_) {
+      col = perform_simple_reduce(
+        col_, agg_descr.agg->kind, /* finalize */ false, agg_descr.output_type);
+    }
+  }
+
+  /*
+   * Function to calculate a final result (called exactly once for each agg).
+   */
+  LogicalColumn calculate_aggregation(
+    const cudf::aggregation& agg,
+    cudf::data_type& output_type,
+    std::optional<std::reference_wrapper<const LogicalColumn>> initial)
+  {
+    switch (agg.kind) {
+      case cudf::aggregation::Kind::MEAN: {
+        /* Mean calculates it's final result from the final sum and counts. */
+        auto sum        = get_result(*cudf::make_sum_aggregation(), output_type, std::nullopt);
+        auto cudf_int64 = cudf::data_type{cudf::type_id::INT64};
+        auto counts     = get_result(*cudf::make_count_aggregation(), cudf_int64, std::nullopt);
+
+        return legate::dataframe::binary_operation(
+          sum, counts, cudf::binary_operator::DIV, output_type);
+      }
+      default: {
+        auto first_pass_res = get_first_pass_result(agg, output_type);
+        // TODO: Use initial here (we may need it, e.g. for sums).
+        return perform_simple_reduce(
+          first_pass_res, agg.kind, /* finalize */ true, output_type, initial);
+      }
+    }
+  }
+
+ private:
+  /*
+   * Results maps, we will fill these with std::nullopt to keep track of what
+   * we still need to calculate.
+   * (If we consider using this for groupby in the future, both result and
+   * `AggregationDescriptor` may need an optional column name.)
+   */
+  const LogicalColumn col_;
+  std::unordered_map<AggregationDescriptor, std::optional<LogicalColumn>, hash_agg_descr> results_;
+  std::unordered_map<AggregationDescriptor, std::optional<LogicalColumn>, hash_agg_descr>
+    first_pass_results_;
+};
+
+}  // namespace
+
+LogicalColumn reduce(const LogicalColumn& col,
+                     const cudf::reduce_aggregation& agg,
+                     cudf::data_type output_type,
+                     std::optional<std::reference_wrapper<const LogicalColumn>> initial)
+{
+  AggregationHelper agg_helper{col};
+  agg_helper.add(agg, output_type, initial);
+
+  /* Aggregations are implemented in two passes, see above. */
+  agg_helper.do_first_pass();
+  return agg_helper.get_result(agg, output_type, initial);
+}
+
+}  // namespace legate::dataframe
+
+namespace {
+
+void __attribute__((constructor)) register_tasks()
+{
+  legate::dataframe::task::ReduceLocalTask::register_variants();
+}
+
+}  // namespace

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,7 +181,10 @@ legate::Type to_legate_type(cudf::type_id dtype)
     case cudf::type_id::DECIMAL128:
     case cudf::type_id::LIST:
     case cudf::type_id::STRUCT:
-    default: throw std::invalid_argument("unsupported cudf datatype");
+    default:
+      throw std::invalid_argument(
+        "unsupported cudf datatype: " +
+        std::to_string(static_cast<std::underlying_type_t<cudf::type_id>>(dtype)));
   }
 }
 

--- a/cpp/tests/test_reduction.cpp
+++ b/cpp/tests/test_reduction.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <legate.h>
+
+#include <cudf/detail/aggregation/aggregation.hpp>  // cudf::detail::target_type
+#include <cudf/reduction.hpp>
+#include <cudf_test/base_fixture.hpp>
+#include <cudf_test/column_utilities.hpp>
+#include <cudf_test/column_wrapper.hpp>
+#include <cudf_test/type_lists.hpp>
+
+#include <legate_dataframe/core/column.hpp>
+#include <legate_dataframe/core/table.hpp>
+#include <legate_dataframe/reduction.hpp>
+
+using namespace legate::dataframe;
+
+template <typename T>
+struct ReductionTest : public cudf::test::BaseFixture {};
+
+TYPED_TEST_SUITE(ReductionTest, cudf::test::NumericTypes);
+
+TYPED_TEST(ReductionTest, Max)
+{
+  cudf::test::fixed_width_column_wrapper<TypeParam> col({5, 6, 7, 8, 9}, {1, 0, 1, 0, 1});
+  auto const type = static_cast<cudf::column_view>(col).type();
+  auto lg_col     = LogicalColumn{col};
+
+  auto agg       = cudf::make_max_aggregation<cudf::reduce_aggregation>();
+  auto res_dtype = cudf::detail::target_type(type, agg->kind);
+
+  auto expected   = cudf::reduce(col, *agg, res_dtype);
+  auto res        = reduce(lg_col, *agg, res_dtype);
+  auto res_scalar = res.get_cudf_scalar();
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(cudf::make_column_from_scalar(*res_scalar, 1)->view(),
+                                 cudf::make_column_from_scalar(*expected, 1)->view());
+}
+
+TYPED_TEST(ReductionTest, Mean)
+{
+  cudf::test::fixed_width_column_wrapper<TypeParam> col({5, 6, 7, 8, 9}, {1, 0, 1, 0, 1});
+  auto const type = static_cast<cudf::column_view>(col).type();
+  auto lg_col     = LogicalColumn{col};
+
+  auto agg       = cudf::make_mean_aggregation<cudf::reduce_aggregation>();
+  auto res_dtype = cudf::detail::target_type(type, agg->kind);
+
+  auto expected   = cudf::reduce(col, *agg, res_dtype);
+  auto res        = reduce(lg_col, *agg, res_dtype);
+  auto res_scalar = res.get_cudf_scalar();
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(cudf::make_column_from_scalar(*res_scalar, 1)->view(),
+                                 cudf::make_column_from_scalar(*expected, 1)->view());
+}
+
+TYPED_TEST(ReductionTest, EmptyMax)
+{
+  cudf::test::fixed_width_column_wrapper<TypeParam> col({});
+  auto const type = static_cast<cudf::column_view>(col).type();
+  auto lg_col     = LogicalColumn{col};
+
+  auto agg       = cudf::make_max_aggregation<cudf::reduce_aggregation>();
+  auto res_dtype = cudf::detail::target_type(type, agg->kind);
+
+  auto expected   = cudf::reduce(col, *agg, res_dtype);
+  auto res        = reduce(lg_col, *agg, res_dtype);
+  auto res_scalar = res.get_cudf_scalar();
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(cudf::make_column_from_scalar(*res_scalar, 1)->view(),
+                                 cudf::make_column_from_scalar(*expected, 1)->view());
+}
+
+TYPED_TEST(ReductionTest, AllNullSum)
+{
+  cudf::test::fixed_width_column_wrapper<TypeParam> col({1, 2, 3, 4}, {1, 1, 1, 1});
+  auto const type = static_cast<cudf::column_view>(col).type();
+  auto lg_col     = LogicalColumn{col};
+
+  auto agg       = cudf::make_max_aggregation<cudf::reduce_aggregation>();
+  auto res_dtype = cudf::detail::target_type(type, agg->kind);
+
+  auto expected   = cudf::reduce(col, *agg, res_dtype);
+  auto res        = reduce(lg_col, *agg, res_dtype);
+  auto res_scalar = res.get_cudf_scalar();
+
+  CUDF_TEST_EXPECT_COLUMNS_EQUAL(cudf::make_column_from_scalar(*res_scalar, 1)->view(),
+                                 cudf::make_column_from_scalar(*expected, 1)->view());
+}

--- a/docs/source/api/column_funcs.rst
+++ b/docs/source/api/column_funcs.rst
@@ -11,6 +11,9 @@ Column functions
     legate_dataframe.lib.timestamps.to_timestamps
 
 .. autofunction::
+    legate_dataframe.lib.reduction.reduce
+
+.. autofunction::
     legate_dataframe.lib.replace.replace_nulls
 
 

--- a/python/legate_dataframe/lib/CMakeLists.txt
+++ b/python/legate_dataframe/lib/CMakeLists.txt
@@ -13,8 +13,8 @@
 # =============================================================================
 
 # Set the list of Cython files to build
-set(cython_sources binaryop.pyx csv.pyx groupby_aggregation.pyx join.pyx parquet.pyx replace.pyx
-                   sort.pyx stream_compaction.pyx timestamps.pyx unaryop.pyx
+set(cython_sources binaryop.pyx csv.pyx groupby_aggregation.pyx join.pyx parquet.pyx reduction.pyx
+                   replace.pyx sort.pyx stream_compaction.pyx timestamps.pyx unaryop.pyx
 )
 
 rapids_cython_create_modules(

--- a/python/legate_dataframe/lib/core/column.pyx
+++ b/python/legate_dataframe/lib/core/column.pyx
@@ -97,6 +97,10 @@ cdef class LogicalColumn:
             return LogicalColumn.from_handle(
                 cpp_LogicalColumn(dereference(scalar.get_raw_ptr()))
             )
+        else:
+            raise TypeError(
+                "from_cudf() only supports cudf columns and device scalars."
+            )
 
     @staticmethod
     def empty_like_logical_column(LogicalColumn col) -> LogicalColumn:

--- a/python/legate_dataframe/lib/reduction.pyx
+++ b/python/legate_dataframe/lib/reduction.pyx
@@ -1,0 +1,61 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# distutils: language = c++
+# cython: language_level=3
+
+from cython.operator cimport dereference
+
+from pylibcudf.aggregation cimport Aggregation
+from pylibcudf.libcudf.aggregation cimport reduce_aggregation
+from pylibcudf.types cimport data_type
+
+from legate_dataframe.lib.core.data_type cimport as_data_type
+from legate_dataframe.lib.core.scalar cimport cpp_scalar_col_from_python
+from legate_dataframe.lib.core.table cimport LogicalColumn, cpp_LogicalColumn
+
+from legate_dataframe.utils import _track_provenance
+
+
+cdef extern from "<legate_dataframe/reduction.hpp>" nogil:
+    cpp_LogicalColumn cpp_reduce "legate::dataframe::reduce"(
+        cpp_LogicalColumn& col, const reduce_aggregation& agg, data_type output_type,
+    ) except +
+    cpp_LogicalColumn cpp_reduce "legate::dataframe::reduce"(
+        cpp_LogicalColumn& col, const reduce_aggregation& agg, data_type output_type,
+        cpp_LogicalColumn& scalar  # actually an optional[reference_type(LogicalColumn)]
+    ) except +
+
+
+@_track_provenance
+def reduce(
+    LogicalColumn col, Aggregation agg, output_type, *, initial=None
+):
+    """Apply a reduction along a column.
+
+    Parameters
+    ----------
+    col
+        The column to reduce.
+    agg
+        The ``pylibcudf.aggregation.Aggregation`` to apply, see
+        :external:py:mod:`pylibcudf.aggregation`.
+        For example, pass ``pylibcudf.aggregation.sum()`` to sum the column.
+    output_type
+        The result dtype, must be specified.
+    initial
+        Scalar column containing an initial value for the reduction.
+    """
+    cdef const reduce_aggregation *cpp_agg = agg.view_underlying_as_reduce()
+    cdef data_type otype = as_data_type(output_type)
+    cdef LogicalColumn initial_col
+
+    if initial is None:
+        return LogicalColumn.from_handle(
+            cpp_reduce(col._handle, dereference(cpp_agg), otype)
+        )
+    else:
+        initial_col = cpp_scalar_col_from_python(initial)
+        return LogicalColumn.from_handle(
+            cpp_reduce(col._handle, dereference(cpp_agg), otype, initial_col._handle)
+        )

--- a/python/tests/test_reduction.py
+++ b/python/tests/test_reduction.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import cudf
+import cupy
+import pytest
+from pylibcudf import aggregation
+
+from legate_dataframe import LogicalColumn
+from legate_dataframe.lib.reduction import reduce
+
+
+@pytest.mark.parametrize("agg", ["mean", "max", "min", "sum", "product"])
+def test_reduce_simple(agg):
+    cupy.random.seed(0)
+    cudf_col = cudf.Series(cupy.random.random(size=1000))
+    lg_col = LogicalColumn.from_cudf(cudf_col._column)
+
+    cudf_res = getattr(cudf_col, agg)()
+    lg_res = reduce(lg_col, getattr(aggregation, agg)(), cudf_res.dtype)
+
+    lg_res_scalar = lg_res.to_cudf_scalar()
+    assert lg_res.is_scalar()  # the result should be marked as scalar
+    assert lg_res_scalar.is_valid()
+    assert lg_res_scalar.value == cudf_res
+
+
+@pytest.mark.parametrize("agg", ["mean", "max", "sum"])
+def test_empty_reduce_simple(agg):
+    # Empty aggregations should return null scalars
+    cudf_col = cudf.Series([], dtype="float64")
+    lg_col = LogicalColumn.from_cudf(cudf_col._column)
+
+    lg_res = reduce(lg_col, getattr(aggregation, agg)(), cudf_col.dtype)
+
+    lg_res_scalar = lg_res.to_cudf_scalar()
+    assert lg_res.is_scalar()
+    assert not lg_res_scalar.is_valid()
+
+
+@pytest.mark.parametrize(
+    "agg,initial", [("sum", 0.5), ("max", 0), ("min", -1), ("product", 2)]
+)
+def test_reduce_initial(agg, initial):
+    cupy.random.seed(0)
+    # Keep values simple to avoid numerical difference:
+    cudf_col = cudf.Series([0.5] * 100)
+    cudf_col[0] = initial
+    # Skip first value, and instead make it the initial:
+    lg_col = LogicalColumn.from_cudf(cudf_col[1:]._column)
+
+    cudf_res = getattr(cudf_col, agg)()
+    lg_res = reduce(
+        lg_col,
+        getattr(aggregation, agg)(),
+        cudf_res.dtype,
+        initial=cudf.Scalar(initial, cudf_col.dtype),
+    )
+
+    lg_res_scalar = lg_res.to_cudf_scalar()
+    assert lg_res.is_scalar()  # the result should be marked as scalar
+    assert lg_res_scalar.is_valid()
+    assert lg_res_scalar.value == cudf_res


### PR DESCRIPTION
This implements basic aggregations using a similar pattern to the simple aggs/finalizer used in parts of cudf.

Since that pattern doesn't take into account the initial value and is in the `detail` API, opted instead to create a custom helper.

That is, we use `(dtype, agg, initial)` to identify each reduce and then split the reduce into two steps:
1. A first-pass that reduces only locally.
2. A finalize pass that works with local results or other final
   results.

Supporting further aggregations should be straight forward additions in the future.

The design should generalize relatively well to re-use for other aggregations (e.g. maybe to improve groupby-aggs) or to calculate multipe aggregations for the same column (since e.g. many need the sum or count temporary result).

The one thing that should be improved is that "count valid" is relatively special and it should possibly become a specialized task and be exposed as explicit API (with `count_nulls()`, we actually should have both probably because `num_rows()` is blocking).

---

I'll note that I did see occasional hangs depending on how tests are run (multi-gpu).  I suspect they are identical to earlier hangs I have seen that seem to originate in legate/legion.