### PR TITLE
API,BUG: Remove `global_num_rows`, use `is_partitioned`

### DIFF
--- a/cpp/include/legate_dataframe/core/column.hpp
+++ b/cpp/include/legate_dataframe/core/column.hpp
@@ -239,18 +239,15 @@ class PhysicalColumn {
    * @param ctx The context of the calling task
    * @param array The logical array (zero copy)
    * @param cudf_type The cudf data type of the column
-   * @param global_num_rows The number of rows of the logical column this physical
    * column is part of. Use a negative value to indicate that the number of rows is
    * unknown.
    */
   PhysicalColumn(GPUTaskContext& ctx,
                  legate::PhysicalArray array,
-                 cudf::data_type cudf_type,
-                 int64_t global_num_rows)
+                 cudf::data_type cudf_type)
     : ctx_{&ctx},
       array_{std::move(array)},
-      cudf_type_{std::move(cudf_type)},
-      global_num_rows_{global_num_rows}
+      cudf_type_{std::move(cudf_type)}
   {
   }
 
@@ -274,18 +271,6 @@ class PhysicalColumn {
     const std::vector<legate::PhysicalStore> ss = get_stores(array_);
     return std::any_of(ss.cbegin(), ss.cend(), [](const auto& s) { return s.is_unbound_store(); });
   }
-
-  /**
-   * @brief Indicates whether the column has been broadcasted or not
-   *
-   * Legate may broadcast small input data such that each task in a parallel launch gets the same
-   * copy of the data.
-   *
-   * @throw std::runtime_error if column is unbound.
-   * @return true The column has been broadcasted to all parallel tasks
-   * @return false The column is distributed between parallel tasks as usual
-   */
-  [[nodiscard]] bool is_broadcasted() const;
 
   /**
    * @brief Get the data type of the underlying logical array
@@ -345,18 +330,18 @@ class PhysicalColumn {
   }
 
   /**
-   * @brief Returns the number of rows of the logical column this physical column is part of.
+   * @brief Returns true if the data is partitioned.
    *
-   * @throw std::runtime_error if the global number of rows are unknown.
-   * @return The number of rows
+   * You can use this to check whether a column is partitioned, please see
+   * `legate::PhysicalStore::is_partitioned` for more information.
+   * This can be used to check whether a column is broadcasted (i.e. partitioned
+   * is false), meaning that all workers see the same data.
+   *
+   * @return true if data is partitioned.
    */
-  [[nodiscard]] int64_t global_num_rows() const
+  [[nodiscard]] bool is_partitioned() const
   {
-    if (global_num_rows_ < 0) {
-      throw std::runtime_error(
-        "The global number of rows are unknown, must likely because the column is/was unbound");
-    }
-    return global_num_rows_;
+    return array_.data().is_partitioned();
   }
 
   /**
@@ -396,7 +381,6 @@ class PhysicalColumn {
   GPUTaskContext* ctx_;
   legate::PhysicalArray array_;
   const cudf::data_type cudf_type_;
-  const int64_t global_num_rows_;
   mutable std::vector<std::unique_ptr<cudf::column>> tmp_cols_;
   mutable std::vector<rmm::device_buffer> tmp_null_masks_;
 };
@@ -439,9 +423,8 @@ inline task::PhysicalColumn get_next_input<task::PhysicalColumn>(GPUTaskContext&
 {
   auto cudf_type_id = static_cast<cudf::type_id>(
     argument::get_next_scalar<std::underlying_type_t<cudf::type_id>>(ctx));
-  auto global_num_rows = argument::get_next_scalar<int64_t>(ctx);
   return task::PhysicalColumn(
-    ctx, ctx.get_next_input_arg(), cudf::data_type{cudf_type_id}, global_num_rows);
+    ctx, ctx.get_next_input_arg(), cudf::data_type{cudf_type_id});
 }
 
 template <>
@@ -449,9 +432,8 @@ inline task::PhysicalColumn get_next_output<task::PhysicalColumn>(GPUTaskContext
 {
   auto cudf_type_id = static_cast<cudf::type_id>(
     argument::get_next_scalar<std::underlying_type_t<cudf::type_id>>(ctx));
-  auto global_num_rows = argument::get_next_scalar<int64_t>(ctx);
   return task::PhysicalColumn(
-    ctx, ctx.get_next_output_arg(), cudf::data_type{cudf_type_id}, global_num_rows);
+    ctx, ctx.get_next_output_arg(), cudf::data_type{cudf_type_id});
 }
 
 }  // namespace argument

--- a/cpp/include/legate_dataframe/core/column.hpp
+++ b/cpp/include/legate_dataframe/core/column.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -242,12 +242,8 @@ class PhysicalColumn {
    * column is part of. Use a negative value to indicate that the number of rows is
    * unknown.
    */
-  PhysicalColumn(GPUTaskContext& ctx,
-                 legate::PhysicalArray array,
-                 cudf::data_type cudf_type)
-    : ctx_{&ctx},
-      array_{std::move(array)},
-      cudf_type_{std::move(cudf_type)}
+  PhysicalColumn(GPUTaskContext& ctx, legate::PhysicalArray array, cudf::data_type cudf_type)
+    : ctx_{&ctx}, array_{std::move(array)}, cudf_type_{std::move(cudf_type)}
   {
   }
 
@@ -339,10 +335,7 @@ class PhysicalColumn {
    *
    * @return true if data is partitioned.
    */
-  [[nodiscard]] bool is_partitioned() const
-  {
-    return array_.data().is_partitioned();
-  }
+  [[nodiscard]] bool is_partitioned() const { return array_.data().is_partitioned(); }
 
   /**
    * @brief Return a cudf column view of this physical column
@@ -423,8 +416,7 @@ inline task::PhysicalColumn get_next_input<task::PhysicalColumn>(GPUTaskContext&
 {
   auto cudf_type_id = static_cast<cudf::type_id>(
     argument::get_next_scalar<std::underlying_type_t<cudf::type_id>>(ctx));
-  return task::PhysicalColumn(
-    ctx, ctx.get_next_input_arg(), cudf::data_type{cudf_type_id});
+  return task::PhysicalColumn(ctx, ctx.get_next_input_arg(), cudf::data_type{cudf_type_id});
 }
 
 template <>
@@ -432,8 +424,7 @@ inline task::PhysicalColumn get_next_output<task::PhysicalColumn>(GPUTaskContext
 {
   auto cudf_type_id = static_cast<cudf::type_id>(
     argument::get_next_scalar<std::underlying_type_t<cudf::type_id>>(ctx));
-  return task::PhysicalColumn(
-    ctx, ctx.get_next_output_arg(), cudf::data_type{cudf_type_id});
+  return task::PhysicalColumn(ctx, ctx.get_next_output_arg(), cudf::data_type{cudf_type_id});
 }
 
 }  // namespace argument

--- a/cpp/include/legate_dataframe/core/table.hpp
+++ b/cpp/include/legate_dataframe/core/table.hpp
@@ -313,19 +313,6 @@ class PhysicalTable {
 
  public:
   /**
-   * @brief Indicates whether the table has been broadcasted or not
-   *
-   * Legate may broadcast small input data such that each task in a parallel launch gets the same
-   * copy of the data.
-   *
-   * @throw std::runtime_error if the table is unbound.
-   * @throw std::runtime_error if some columns are broadcasted and some are not.
-   * @return true The table has been broadcasted to all parallel tasks
-   * @return false The table is distributed between parallel tasks as usual
-   */
-  [[nodiscard]] bool is_broadcasted() const;
-
-  /**
    * @brief Returns the number of columns
    *
    * @return The number of columns
@@ -384,6 +371,25 @@ class PhysicalTable {
       col.bind_empty_data();
     }
   }
+
+  /**
+   * @brief Returns true if the data is partitioned.
+   *
+   * You can use this to check whether a column is partitioned, please see
+   * `legate::PhysicalStore::is_partitioned` for more information.
+   * This can be used to check whether a column is broadcasted (i.e. partitioned
+   * is false), meaning that all workers see the same data.
+   *
+   * This function relies on tables always adding an alignment constraint.
+   *
+   * @throw std::out_of_range if the table doesn't have at least one column.
+   * @return true if data is partitioned.
+   */
+  [[nodiscard]] bool is_partitioned() const
+  {
+    return columns_.at(0).is_partitioned();
+  }
+
   /**
    * @brief Releases ownership of the `column`s by returning a vector of
    * the constituent columns.

--- a/cpp/include/legate_dataframe/core/table.hpp
+++ b/cpp/include/legate_dataframe/core/table.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -385,10 +385,7 @@ class PhysicalTable {
    * @throw std::out_of_range if the table doesn't have at least one column.
    * @return true if data is partitioned.
    */
-  [[nodiscard]] bool is_partitioned() const
-  {
-    return columns_.at(0).is_partitioned();
-  }
+  [[nodiscard]] bool is_partitioned() const { return columns_.at(0).is_partitioned(); }
 
   /**
    * @brief Releases ownership of the `column`s by returning a vector of

--- a/cpp/src/core/column.cu
+++ b/cpp/src/core/column.cu
@@ -232,11 +232,6 @@ std::string LogicalColumn::repr(size_t max_num_items) const
 
 namespace task {
 
-bool PhysicalColumn::is_broadcasted() const
-{
-  return ctx_->nranks > 1 && num_rows() == global_num_rows();
-}
-
 std::string PhysicalColumn::repr(legate::Memory::Kind mem_kind,
                                  cudaStream_t stream,
                                  size_t max_num_items) const
@@ -430,7 +425,6 @@ namespace argument {
 legate::Variable add_next_input(legate::AutoTask& task, const LogicalColumn& col, bool broadcast)
 {
   add_next_scalar(task, static_cast<std::underlying_type_t<cudf::type_id>>(col.cudf_type().id()));
-  add_next_scalar(task, col.unbound() ? -1 : static_cast<int64_t>(col.num_rows()));
   auto arr      = col.get_logical_array();
   auto variable = task.add_input(arr);
   if (broadcast) { task.add_constraint(legate::broadcast(variable, {0})); }
@@ -440,7 +434,6 @@ legate::Variable add_next_input(legate::AutoTask& task, const LogicalColumn& col
 legate::Variable add_next_output(legate::AutoTask& task, const LogicalColumn& col)
 {
   add_next_scalar(task, static_cast<std::underlying_type_t<cudf::type_id>>(col.cudf_type().id()));
-  add_next_scalar(task, col.unbound() ? -1 : static_cast<int64_t>(col.num_rows()));
   return {task.add_output(col.get_logical_array())};
 }
 

--- a/cpp/src/core/table.cpp
+++ b/cpp/src/core/table.cpp
@@ -122,22 +122,6 @@ std::string LogicalTable::repr(size_t max_num_items_ptr_column) const
   return ss.str();
 }
 
-namespace task {
-
-bool PhysicalTable::is_broadcasted() const
-{
-  const bool ret = std::any_of(
-    columns_.cbegin(), columns_.cend(), [](const auto& col) { return col.is_broadcasted(); });
-
-  if (ret && !std::all_of(columns_.cbegin(), columns_.cend(), [](const auto& col) {
-        return col.is_broadcasted();
-      })) {
-    throw std::runtime_error("A table cannot mix broadcasted and non-broadcasted columns");
-  }
-  return ret;
-}
-}  // namespace task
-
 namespace argument {
 std::vector<legate::Variable> add_next_input(legate::AutoTask& task,
                                              const LogicalTable& tbl,

--- a/cpp/tests/test_task.cpp
+++ b/cpp/tests/test_task.cpp
@@ -37,16 +37,12 @@ struct GlobalRowOffsetTask : public legate::LegateTask<GlobalRowOffsetTask> {
     GPUTaskContext ctx{context};
     auto tbl                               = argument::get_next_input<task::PhysicalTable>(ctx);
     auto output                            = argument::get_next_output<task::PhysicalColumn>(ctx);
-    auto global_num_rows                   = argument::get_next_scalar<int64_t>(ctx);
     std::vector<task::PhysicalColumn> cols = tbl.release();
     int64_t offset                         = cols.at(0).global_row_offset();
     int64_t nrows                          = cols.at(0).num_rows();
 
     // We expect the columns of a table are aligned.
     EXPECT_EQ(offset, cols.at(1).global_row_offset());
-
-    // Check the global number of rows
-    EXPECT_EQ(global_num_rows, cols.at(0).global_num_rows());
 
     // Write our row offset and size
     cudf::test::fixed_width_column_wrapper<int64_t> out({offset, nrows});
@@ -76,21 +72,21 @@ struct TaskArgumentMix : public legate::LegateTask<TaskArgumentMix> {
     const auto input = argument::get_next_input<task::PhysicalColumn>(ctx);
     {
       auto [scalar_idx, input_idx, output_idx] = ctx.get_task_argument_indices();
-      EXPECT_EQ(scalar_idx, 2);
+      EXPECT_EQ(scalar_idx, 1);
       EXPECT_EQ(input_idx, 1);
       EXPECT_EQ(output_idx, 0);
     }
     auto output = argument::get_next_output<task::PhysicalColumn>(ctx);
     {
       auto [scalar_idx, input_idx, output_idx] = ctx.get_task_argument_indices();
-      EXPECT_EQ(scalar_idx, 4);
+      EXPECT_EQ(scalar_idx, 2);
       EXPECT_EQ(input_idx, 1);
       EXPECT_EQ(output_idx, 1);
     }
     auto scalar = argument::get_next_scalar<int32_t>(ctx);
     {
       auto [scalar_idx, input_idx, output_idx] = ctx.get_task_argument_indices();
-      EXPECT_EQ(scalar_idx, 5);
+      EXPECT_EQ(scalar_idx, 3);
       EXPECT_EQ(input_idx, 1);
       EXPECT_EQ(output_idx, 1);
     }

--- a/python/tests/test_join.py
+++ b/python/tests/test_join.py
@@ -18,6 +18,7 @@ import cupy
 import pytest
 
 from legate_dataframe import LogicalTable
+from legate_dataframe.lib.stream_compaction import apply_boolean_mask
 from legate_dataframe.lib.join import BroadcastInput, JoinType, join
 from legate_dataframe.testing import assert_frame_equal
 
@@ -128,3 +129,31 @@ def test_column_names():
         cudf.DataFrame({"data0": [1, 2, 3], "key": [1, 2, 3], "data1": [3, 2, 1]}),
         ignore_row_order=True,
     )
+
+
+@pytest.mark.parametrize("threshold", [0, 2])
+def test_empty_chunks(threshold):
+    # Check that the join code deals gracefully if most/all ranks have no
+    # data at all.  `apply_boolean_mask` creates such dataframes.
+    values = cupy.arange(-100, 100)
+    # Create a mask that has very few true values in the middle:
+    lhs_df = cudf.DataFrame({"a": values, "mask": abs(values) <= threshold})
+    lhs_lg_df = LogicalTable.from_cudf(lhs_df)
+
+    lhs_df = lhs_df[lhs_df["mask"]]
+    lhs_lg_df = apply_boolean_mask(lhs_lg_df, lhs_lg_df["mask"])
+
+    # Values exist, but not at the same place:
+    rhs_df = cudf.DataFrame({"b": cupy.arange(0, 200)})
+    rhs_lg_df = LogicalTable.from_cudf(rhs_df)
+
+    lg_result = join(
+        lhs_lg_df,
+        rhs_lg_df,
+        lhs_keys=["a"],
+        rhs_keys=["b"],
+        join_type=JoinType.INNER,
+    )
+    df_result = lhs_df.merge(rhs_df, left_on=["a"], right_on=["b"])
+
+    assert_frame_equal(lg_result, df_result)

--- a/python/tests/test_join.py
+++ b/python/tests/test_join.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION
+# Copyright (c) 2023-2025, NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ import cupy
 import pytest
 
 from legate_dataframe import LogicalTable
-from legate_dataframe.lib.stream_compaction import apply_boolean_mask
 from legate_dataframe.lib.join import BroadcastInput, JoinType, join
+from legate_dataframe.lib.stream_compaction import apply_boolean_mask
 from legate_dataframe.testing import assert_frame_equal
 
 

--- a/python/tests/test_sort.py
+++ b/python/tests/test_sort.py
@@ -17,6 +17,7 @@ import cudf
 import cupy
 import numpy as np
 import pytest
+from legate.core import get_legate_runtime
 
 from legate_dataframe import LogicalTable
 from legate_dataframe.lib.sort import NullOrder, Order, sort
@@ -109,6 +110,9 @@ def test_shifted_equal_window(reversed):
         df_sorted = df.sort_values(by=["a"], kind="stable")
 
         assert_frame_equal(lg_sorted, df_sorted)
+
+        # Block for stability with lower memory (not sure if it should be here)
+        get_legate_runtime().issue_execution_fence(block=True)
 
 
 @pytest.mark.parametrize("stable", [True, False])


### PR DESCRIPTION
This is breaking as we stop passing around `global_num_rows`, but this
should improve legate's ability to parallelize task launches (I think)
since fetching the `global_num_rows` on an unbound table requires blocking.

`is_partitioned` should also be a safer API here, because the local and
global number of rows could be equal if all but one chunks have 0 entries
(which is may be hard to trigger but is possible with filtering).

---

* I removed `global_num_rows` for now.  It may well be useful again eventually.
* The test did hang without the fix, but not 100% sure if that was actually the bug I expected :).