### PR TITLE
Replace `conda-mambabuild`with `conda-build`

### DIFF
--- a/ci/build_all.sh
+++ b/ci/build_all.sh
@@ -16,7 +16,7 @@ sccache --zero-stats
 CMAKE_GENERATOR=Ninja \
 CONDA_OVERRIDE_CUDA="${RAPIDS_CUDA_VERSION}" \
 LEGATEDATAFRAME_PACKAGE_VERSION="$(head -1 ./VERSION)" \
-rapids-conda-retry mambabuild \
+rapids-conda-retry build \
     --channel legate \
     --channel legate/label/rc \
     --channel legate/label/experimental \


### PR DESCRIPTION
## Description

These are now equivalent in behavior. However support for `conda-mambabuild` is being dropped. So switch to `conda-build`.

xref: https://github.com/rapidsai/build-planning/issues/149

## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [ ] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
