### PR TITLE
API: Allow parquet reading into (transposed) array

### DIFF
--- a/ci/build_docs.sh
+++ b/ci/build_docs.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -e -E -u -o pipefail
 
@@ -44,4 +44,6 @@ rapids-mamba-retry install \
 
 rapids-print-env
 
+# Make documentation, we need gpu but otherwise minimal resources
+LEGATE_CONFIG="--omps=0 --gpus=1 --fbmem=100 --cpus=1 --utility=1" \
 make -C docs html

--- a/ci/run_ctests.sh
+++ b/ci/run_ctests.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2024, NVIDIA CORPORATION.
+# Copyright (c) 2024-2025, NVIDIA CORPORATION.
 
 set -euo pipefail
 
@@ -13,6 +13,6 @@ fi
 
 # Unless `LEGATE_CONFIG` is set, default to all available GPUs and set fbmem/sysmem.
 # LEGATE_TEST=1 to test broadcasting code paths (locally).
-LEGATE_CONFIG=${LEGATE_CONFIG:- --gpus="$(nvidia-smi -L | wc -l) --fbmem=4000 --sysmem=4000"} \
+LEGATE_CONFIG=${LEGATE_CONFIG:- --gpus="$(nvidia-smi -L | wc -l)" --fbmem=2000 --sysmem=6000 --omps=0} \
 LEGATE_TEST=${LEGATE_TEST:-1} \
 legate ./cpp_tests --output-on-failure --no-tests=error "$@"

--- a/ci/run_pytests.sh
+++ b/ci/run_pytests.sh
@@ -21,7 +21,7 @@ cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"/../python/tests/
 # Unless `LEGATE_CONFIG` is set, default to all available GPUs and set fbmem/sysmem.
 # The choice of 2000 and 6000 allows some large memory tests to run (on a single GPU).
 # LEGATE_TEST=1 to test broadcasting code paths (locally).
-LEGATE_CONFIG=${LEGATE_CONFIG:- --gpus="$(nvidia-smi -L | wc -l) --fbmem=2000 --sysmem=6000"} \
+LEGATE_CONFIG=${LEGATE_CONFIG:- --gpus="$(nvidia-smi -L | wc -l)" --fbmem=2000 --sysmem=6000 --omps=0} \
 LEGATE_TEST=${LEGATE_TEST:-1} \
 legate \
     --module pytest \

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 # =============================================================================
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 # in compliance with the License. You may obtain a copy of the License at
@@ -107,6 +107,14 @@ set_target_properties(
              CUDA_STANDARD_REQUIRED ON
              POSITION_INDEPENDENT_CODE ON
              INTERFACE_POSITION_INDEPENDENT_CODE ON
+)
+
+list(APPEND LDF_CUDA_FLAGS --expt-extended-lambda)
+list(APPEND LDF_CUDA_FLAGS --expt-relaxed-constexpr)
+
+target_compile_options(
+  LegateDataframe PRIVATE "$<$<COMPILE_LANGUAGE:CXX>:${LDF_CXX_FLAGS}>"
+                          "$<$<COMPILE_LANGUAGE:CUDA>:${LDF_CUDA_FLAGS}>"
 )
 
 target_include_directories(

--- a/cpp/include/legate_dataframe/core/transposed_copy.cuh
+++ b/cpp/include/legate_dataframe/core/transposed_copy.cuh
@@ -26,6 +26,7 @@ namespace legate::dataframe {
 void copy_into_tranposed(GPUTaskContext& ctx,
                          legate::PhysicalArray& array,
                          cudf::table_view tbl,
-                         size_t offset);
+                         size_t offset,
+                         legate::Scalar& null_value);
 
 }  // namespace legate::dataframe

--- a/cpp/include/legate_dataframe/core/transposed_copy.cuh
+++ b/cpp/include/legate_dataframe/core/transposed_copy.cuh
@@ -17,45 +17,15 @@
 #pragma once
 
 #include <legate.h>
-#include <legate/mapping/mapping.h>
+
+#include <cudf/table/table_view.hpp>
+#include <legate_dataframe/core/task_context.hpp>
 
 namespace legate::dataframe {
-namespace task {
 
-namespace OpCode {
-enum : int {
-  ApplyBooleanMask,
-  CSVWrite,
-  CSVRead,
-  ParquetWrite,
-  ParquetRead,
-  ParquetReadArray,
-  ReplaceNullsWithScalar,
-  UnaryOp,
-  BinaryOpColCol,
-  BinaryOpColScalar,
-  BinaryOpScalarCol,
-  Join,
-  ToTimestamps,
-  ExtractTimestampComponent,
-  ReduceLocal,
-  Sequence,
-  Sort,
-  GroupByAggregation
-};
-}
-
-struct Registry {
-  static legate::TaskRegistrar& get_registrar();
-};
-
-template <typename T, int ID>
-struct Task : public legate::LegateTask<T> {
-  using Registrar = Registry;
-};
-
-}  // namespace task
-
-legate::Library& get_library();
+void copy_into_tranposed(GPUTaskContext& ctx,
+                         legate::PhysicalArray& array,
+                         cudf::table_view tbl,
+                         size_t offset);
 
 }  // namespace legate::dataframe

--- a/cpp/include/legate_dataframe/parquet.hpp
+++ b/cpp/include/legate_dataframe/parquet.hpp
@@ -61,4 +61,20 @@ void parquet_write(LogicalTable& tbl, const std::string& dirpath);
 LogicalTable parquet_read(const std::string& glob_string,
                           const std::optional<std::vector<std::string>>& columns = std::nullopt);
 
+/**
+ * @brief Read Parquet files into a legate Array
+ *
+ * Note that file order is currently glob/string sorted.  All columns that are being read must have
+ * the same type and be compatible with a legate type, currently only numeric types are supported.
+ *
+ * @param glob_string The glob string to specify the Parquet files. All glob matches must be valid
+ * Parquet files and have the same LogicalTable data types. See <https://linux.die.net/man/7/glob>.
+ * @param columns The columns names to read.
+ * @param nullable If set to ``False``, assume that the file does contain any nulls.
+ * @return The read LogicalTable
+ */
+legate::LogicalArray parquet_read_array(const std::string& glob_string,
+                                        const std::optional<std::vector<std::string>>& columns,
+                                        const bool nullable);
+
 }  // namespace legate::dataframe

--- a/cpp/include/legate_dataframe/parquet.hpp
+++ b/cpp/include/legate_dataframe/parquet.hpp
@@ -75,6 +75,7 @@ LogicalTable parquet_read(const std::string& glob_string,
  */
 legate::LogicalArray parquet_read_array(const std::string& glob_string,
                                         const std::optional<std::vector<std::string>>& columns,
-                                        const bool nullable);
+                                        const legate::Scalar& null_value,
+                                        const std::optional<legate::Type>& type);
 
 }  // namespace legate::dataframe

--- a/cpp/src/core/transposed_copy.cu
+++ b/cpp/src/core/transposed_copy.cu
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuda/functional>
+#include <thrust/execution_policy.h>
+#include <thrust/functional.h>
+#include <thrust/transform.h>
+
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/exec_policy.hpp>
+
+#include <cudf/table/table_device_view.cuh>
+
+#include <legate_dataframe/core/task_context.hpp>
+#include <legate_dataframe/utils.hpp>
+
+namespace legate::dataframe {
+
+namespace {
+
+template <typename T, typename Enable = void>
+struct copy_into_transposed_fn {
+  template <typename... Args>
+  void operator()(Args&&...)
+  {
+    throw std::runtime_error("copy_into_transposed(): type not supported");
+  }
+};
+
+struct copy_into_transposed_impl {
+  template <typename T>
+  void operator()(GPUTaskContext& ctx,
+                  legate::PhysicalArray& array,
+                  cudf::table_view tbl,
+                  size_t offset)
+  {
+    copy_into_transposed_fn<T>{}(ctx, array, tbl, offset);
+  }
+};
+
+template <typename T>
+struct copy_into_transposed_fn<T, std::enable_if_t<cudf::is_rep_layout_compatible<T>()>> {
+  void operator()(GPUTaskContext& ctx,
+                  legate::PhysicalArray& array,
+                  cudf::table_view tbl,
+                  size_t offset)
+  {
+    legate::Rect<2> bounds{{offset, 0}, {offset + tbl.num_rows() - 1, tbl.num_columns() - 1}};
+    if (bounds.empty()) { return; }
+
+    auto acc = array.data().write_accessor<T, 2, true>();
+    if (!acc.accessor.is_dense_row_major(bounds)) {
+      throw std::runtime_error("internal error: copy_into_transpose assume C-order store (data).");
+    }
+
+    // Similar to cudf's interleave_columns (we don't want to allocate, so avoid it).
+    auto device_input = cudf::table_device_view::create(tbl, ctx.stream());
+
+    auto get_value_func = cuda::proclaim_return_type<T>(
+      [input = *device_input, divisor = tbl.num_columns()] __device__(size_t idx) {
+        return input.column(idx % divisor).element<T>(idx / divisor);
+      });
+
+    auto index_begin = thrust::make_counting_iterator<size_t>(0);
+    auto index_end   = thrust::make_counting_iterator<size_t>(bounds.volume());
+
+    // This assumes that for rep_layout_compatible types `.element<T>(idx)` is OK even for masked
+    // values.
+    thrust::transform(
+      rmm::exec_policy(ctx.stream()), index_begin, index_end, acc.ptr(bounds.lo), get_value_func);
+
+    if (!array.nullable()) { return; }
+
+    auto get_isvalid_func = cuda::proclaim_return_type<bool>(
+      [input = *device_input, divisor = tbl.num_columns()] __device__(size_t idx) {
+        return input.column(idx % divisor).is_valid_nocheck(idx / divisor);
+      });
+
+    auto mask_acc = array.null_mask().write_accessor<bool, 2, true>();
+    if (!mask_acc.accessor.is_dense_row_major(bounds)) {
+      throw std::runtime_error("internal error: copy_into_transpose assume C-order store (mask).");
+    }
+
+    thrust::transform(rmm::exec_policy(ctx.stream()),
+                      index_begin,
+                      index_end,
+                      mask_acc.ptr(bounds.lo),
+                      get_isvalid_func);
+  }
+};
+
+}  // namespace
+
+void copy_into_tranposed(GPUTaskContext& ctx,
+                         legate::PhysicalArray& array,
+                         cudf::table_view tbl,
+                         size_t offset)
+{
+  for (auto&& col : tbl) {
+    if (to_cudf_type_id(array.type().code()) != col.type().id()) {
+      throw std::runtime_error("internal error: column types changed between files?");
+    }
+    if (!array.nullable() && col.null_count() > 0) {
+      throw std::invalid_argument("file is assumed to not contain nulls.");
+    }
+  }
+
+  cudf::type_dispatcher(tbl.column(0).type(), copy_into_transposed_impl{}, ctx, array, tbl, offset);
+}
+
+}  // namespace legate::dataframe

--- a/docs/source/api/io.rst
+++ b/docs/source/api/io.rst
@@ -8,6 +8,9 @@ Parquet files
     legate_dataframe.lib.parquet.parquet_read
 
 .. autofunction::
+    legate_dataframe.lib.parquet.parquet_read_array
+
+.. autofunction::
     legate_dataframe.lib.parquet.parquet_write
 
 

--- a/python/legate_dataframe/lib/core/legate.pxd
+++ b/python/legate_dataframe/lib/core/legate.pxd
@@ -13,3 +13,9 @@ cdef extern from "legate.h":
         FBMEM
         ZCMEM
         SOCKETMEM
+
+    cdef cppclass cpp_Scalar "legate::Scalar":
+        pass
+
+    cdef cppclass cpp_Type "legate::Type":
+        pass

--- a/python/legate_dataframe/lib/parquet.pyi
+++ b/python/legate_dataframe/lib/parquet.pyi
@@ -7,7 +7,7 @@
 import pathlib
 from typing import Iterable
 
-from legate.core import LogicalArray
+import legate.core
 
 from legate_dataframe.lib.core.table import LogicalTable
 
@@ -18,6 +18,7 @@ def parquet_read(
 def parquet_read_array(
     glob_string: pathlib.Path | str,
     *,
-    columns: Iterable[str] | None,
-    nullable: bool = True,
-) -> LogicalArray: ...
+    columns: Iterable[str] | None = None,
+    null_value: legate.core.Scalar | None = None,
+    type: legate.core.Type | None = None,
+) -> legate.core.LogicalArray: ...

--- a/python/legate_dataframe/lib/parquet.pyi
+++ b/python/legate_dataframe/lib/parquet.pyi
@@ -7,9 +7,17 @@
 import pathlib
 from typing import Iterable
 
+from legate.core import LogicalArray
+
 from legate_dataframe.lib.core.table import LogicalTable
 
 def parquet_write(tbl: LogicalTable, path: pathlib.Path | str) -> None: ...
 def parquet_read(
     glob_string: pathlib.Path | str, *, columns: Iterable[str] | None
 ) -> LogicalTable: ...
+def parquet_read_array(
+    glob_string: pathlib.Path | str,
+    *,
+    columns: Iterable[str] | None,
+    nullable: bool = True,
+) -> LogicalArray: ...

--- a/python/tests/test_parquet.py
+++ b/python/tests/test_parquet.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION
+# Copyright (c) 2023-2025, NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,13 +20,14 @@ import dask_cudf
 import pytest
 from legate.core import get_legate_runtime
 
-from legate_dataframe import LogicalTable
-from legate_dataframe.lib.parquet import parquet_read, parquet_write
+from legate_dataframe import LogicalColumn, LogicalTable
+from legate_dataframe.lib.parquet import parquet_read, parquet_read_array, parquet_write
 from legate_dataframe.testing import assert_frame_equal, std_dataframe_set
 
 
 @pytest.mark.parametrize("df", std_dataframe_set())
 def test_write(tmp_path, df):
+    print(tmp_path)
     tbl = LogicalTable.from_cudf(df)
 
     parquet_write(tbl, path=tmp_path)
@@ -80,3 +81,50 @@ def test_read_many_files_per_rank(tmp_path, glob_string="/*"):
     #       files.  So more with more than 10 files the order of rows is not
     #       preserved at this time.
     assert_frame_equal(tbl.to_cudf().sort_values(by="a"), df)
+
+
+def test_read_array(tmp_path, npartitions=2, glob_string="/*"):
+    cn = pytest.importorskip("cupynumeric")
+
+    c = cudf.Series(cupy.arange(2, 10002, dtype="float32"))
+    c = c.mask([True, False] * 5000)
+    df = cudf.DataFrame(
+        {
+            "a": cupy.arange(10000, dtype="float32"),
+            "b": cupy.arange(1, 10001, dtype="float32"),
+            "c": c,  # only column with masked values
+            "d": cupy.arange(3, 10003, dtype="float32"),
+        }
+    )
+    ddf = dask_cudf.from_cudf(df, npartitions=npartitions)
+    ddf.to_parquet(path=tmp_path, index=False)
+
+    tbl = parquet_read(str(tmp_path) + glob_string, columns=["b", "a", "d"])
+    arr_from_tbl = tbl.to_array()
+    arr = parquet_read_array(
+        str(tmp_path) + glob_string, columns=["b", "a", "d"], nullable=False
+    )
+    arr = cn.asarray(arr)
+
+    assert arr.dtype == arr_from_tbl.dtype
+    assert cn.array_equal(arr_from_tbl, arr)
+
+    # Check if the mask behavior seems right for column "c"
+    arr = parquet_read_array(str(tmp_path) + glob_string, columns=["c"], nullable=True)
+    col_from_arr = LogicalColumn(arr.project(1, 0))
+    col = parquet_read(str(tmp_path) + glob_string, columns=["c"])["c"]
+
+    assert_frame_equal(col_from_arr, col)
+
+
+def test_read_array_large(tmp_path, npartitions=1, glob_string="/*"):
+    cn = pytest.importorskip("cupynumeric")
+
+    # Create an array so large, that we should chunk (should be fine for testing)
+    df = cudf.DataFrame({"a": cupy.ones(2**26, dtype="uint8")})
+    ddf = dask_cudf.from_cudf(df, npartitions=npartitions)
+    ddf.to_parquet(path=tmp_path, index=False)
+    del df, ddf
+
+    arr = parquet_read_array(str(tmp_path) + glob_string, columns=["a"], nullable=False)
+    assert cn.asarray(arr).sum() == 2**26

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -1,4 +1,4 @@
-# Copyright 2024 NVIDIA Corporation
+# Copyright (c) 2024-2025, NVIDIA CORPORATION
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ def test_python_launched_tasks():
 
     # Then, we can create the task and provide the task arguments using the
     # exact same order as in the task implementation ("unaryop.cpp").
-    task = runtime.create_auto_task(lib, 6)  # TODO: get the enum of `UnaryOperator`
+    task = runtime.create_auto_task(lib, 7)  # TODO: get the enum of `UnaryOperator`
     task.add_scalar_arg(UnaryOperator.ABS.value, dtype=lg_type.int32)
     col.add_as_next_task_input(task)
     result = LogicalColumn.empty_like_logical_column(col)


### PR DESCRIPTION
This adds a call to do a chunked copy directly into a transposed array. To be honest, the only reason to do this inside legate-df, is that we have the cudf dependency here anyway.
To some degree, the reason is just to work-around current legate issues with too many columns.

---

Always trickier then I expect... @RAMitchell this should allow reading in these huge tables, effectively directly to cupynumeric via `nullable=False` and then just using `cupynumeric.asarray()`.

I am not sure if the chunking choice here is ideal, i.e. whether this is as faster as it can be.  The tranpose-copy is very similar to the "interleaved copy" in cudf, and I can imagine that it could be sped up as well.