### PR TITLE
API: Add `unaryop.cast` to cast a single column

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@ This is **not** a drop-in replacement of [Pandas](https://pandas.pydata.org/), i
 
 In the future, we plan to introduce a high-level pure Python package that implements all the nice-to-have features known from Pandas using the low-level API's primitives.
 
+[Python API and further documentation](https://rapidsai.github.io/legate-dataframe/).
+
 ## Install
 
 You can install `legate-dataframe` packages from the [conda legate channel](https://anaconda.org/legate/)
 using
 ```bash
-conda -c legate -c rapidsai -c conda-forge legate-dataframe
+conda install -c legate -c rapidsai -c conda-forge legate-dataframe
 ```
 To include development releases add the `legate/label/experimental` channel.
 

--- a/cpp/include/legate_dataframe/core/library.hpp
+++ b/cpp/include/legate_dataframe/core/library.hpp
@@ -27,6 +27,7 @@ enum : int {
   ApplyBooleanMask,
   CSVWrite,
   CSVRead,
+  Cast,
   ParquetWrite,
   ParquetRead,
   ParquetReadArray,

--- a/cpp/include/legate_dataframe/unaryop.hpp
+++ b/cpp/include/legate_dataframe/unaryop.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,16 @@
 #include <legate_dataframe/core/column.hpp>
 
 namespace legate::dataframe {
+
+/**
+ * @brief Cast column to a new data type.
+ *
+ * @param col Logical column as input
+ * @param dtype The desired data type of the output column
+ *
+ * @returns Logical column of same size as `col` of the new data type
+ */
+LogicalColumn cast(const LogicalColumn& col, cudf::data_type dtype);
 
 /**
  * @brief Performs unary operation on all values in column

--- a/docs/source/api/column_funcs.rst
+++ b/docs/source/api/column_funcs.rst
@@ -2,6 +2,9 @@ Column functions
 ================
 
 .. autofunction::
+    legate_dataframe.lib.unaryop.cast
+
+.. autofunction::
     legate_dataframe.lib.unaryop.unary_operation
 
 .. autofunction::
@@ -9,6 +12,9 @@ Column functions
 
 .. autofunction::
     legate_dataframe.lib.timestamps.to_timestamps
+
+.. autofunction::
+    legate_dataframe.lib.timestamps.extract_timestamp_component
 
 .. autofunction::
     legate_dataframe.lib.reduction.reduce

--- a/python/legate_dataframe/lib/unaryop.pyi
+++ b/python/legate_dataframe/lib/unaryop.pyi
@@ -3,8 +3,11 @@
 
 from enum import Enum
 
+from numpy.typing import DTypeLike
+
 from legate_dataframe.lib.core.column import LogicalColumn
 
 class unary_operator(Enum): ...
 
 def unary_operation(col: LogicalColumn, op: unary_operator) -> LogicalColumn: ...
+def cast(col: LogicalColumn, dtype: DTypeLike) -> LogicalColumn: ...

--- a/python/legate_dataframe/lib/unaryop.pyx
+++ b/python/legate_dataframe/lib/unaryop.pyx
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # distutils: language = c++
@@ -6,7 +6,10 @@
 
 from libc.stdint cimport int32_t
 
+from pylibcudf.types cimport data_type
+
 from legate_dataframe.lib.core.column cimport LogicalColumn, cpp_LogicalColumn
+from legate_dataframe.lib.core.data_type cimport as_data_type
 from legate_dataframe.utils import _track_provenance
 
 
@@ -43,6 +46,10 @@ cdef extern from "<legate_dataframe/unaryop.hpp>" nogil:
         const cpp_LogicalColumn& col, unary_operator op
     ) except +
 
+    cpp_LogicalColumn cpp_cast "legate::dataframe::cast"(
+        const cpp_LogicalColumn& col, data_type dtype
+    ) except +
+
 
 @_track_provenance
 def unary_operation(LogicalColumn col, unary_operator op) -> LogicalColumn:
@@ -63,4 +70,24 @@ def unary_operation(LogicalColumn col, unary_operator op) -> LogicalColumn:
     """
     return LogicalColumn.from_handle(
         cpp_unary_operation(col._handle, op)
+    )
+
+
+@_track_provenance
+def cast(LogicalColumn col, dtype) -> LogicalColumn:
+    """Cast a logical column to the desired data type.
+
+    Parameters
+    ----------
+    col
+        Logical column as input
+    dtype
+        The cudf data type of the result.
+
+    Returns
+    -------
+        Logical column of same size as `col` but with new data type.
+    """
+    return LogicalColumn.from_handle(
+        cpp_cast(col._handle, as_data_type(dtype))
     )

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -38,7 +38,7 @@ def test_python_launched_tasks():
 
     # Then, we can create the task and provide the task arguments using the
     # exact same order as in the task implementation ("unaryop.cpp").
-    task = runtime.create_auto_task(lib, 7)  # TODO: get the enum of `UnaryOperator`
+    task = runtime.create_auto_task(lib, 8)  # TODO: get the enum of `UnaryOperator`
     task.add_scalar_arg(UnaryOperator.ABS.value, dtype=lg_type.int32)
     col.add_as_next_task_input(task)
     result = LogicalColumn.empty_like_logical_column(col)


### PR DESCRIPTION
Add API to allow casting a single column (for now functional).