### PR TITLE
add shellcheck to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,11 @@ repos:
     hooks:
       - id: clang-format
         types_or: [c, c++, cuda]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: ["--severity=warning"]
   - repo: https://github.com/rapidsai/pre-commit-hooks
     rev: v0.6.0
     hooks:
@@ -78,7 +83,7 @@ repos:
             ^CHANGELOG.md$
           )
   - repo: https://github.com/rapidsai/dependency-file-generator
-    rev: v1.17.1
+    rev: v1.18.1
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (c) 2023-2024, NVIDIA CORPORATION.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 # legate_dataframe build script
@@ -16,7 +16,7 @@ ARGS=$*
 
 # NOTE: ensure all dir changes are relative to the location of this
 # script, and that this script resides in the repo dir!
-REPODIR=$(cd $(dirname $0); pwd)
+REPODIR=$(cd "$(dirname "$0")"; pwd)
 
 VALIDARGS="clean liblegate_dataframe legate_dataframe test -v -g -n -s --ptds -h"
 HELP="$0 [clean] [liblegate_dataframe] [legate_dataframe] [legate] [-v] [-g] [-n] [-s] [--ptds] [--cmake-args=\"<args>\"] [-h]

--- a/scripts/run-cmake-format.sh
+++ b/scripts/run-cmake-format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2021-2024, NVIDIA CORPORATION.
+# Copyright (c) 2021-2025, NVIDIA CORPORATION.
 # SPDX-License-Identifier: Apache-2.0
 
 # This script is a wrapper for cmakelang that may be used with pre-commit. The
@@ -49,7 +49,7 @@ DEFAULT_FORMAT_FILE_LOCATIONS=(
 )
 
 if [ -z ${RAPIDS_CMAKE_FORMAT_FILE:+PLACEHOLDER} ]; then
-    for file_path in ${DEFAULT_FORMAT_FILE_LOCATIONS[@]}; do
+    for file_path in "${DEFAULT_FORMAT_FILE_LOCATIONS[@]}"; do
         if [ -f ${file_path} ]; then
             RAPIDS_CMAKE_FORMAT_FILE=${file_path}
             break
@@ -69,12 +69,12 @@ else
 fi
 
 if [[ $1 == "cmake-format" ]]; then
-  cmake-format -i --config-files cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2}
+  cmake-format -i --config-files cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- "${@:2}"
 elif [[ $1 == "cmake-lint" ]]; then
   # Since the pre-commit hook is verbose, we have to be careful to only
   # present cmake-lint's output (which is quite verbose) if we actually
   # observe a failure.
-  OUTPUT=$(cmake-lint --config-files cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- ${@:2})
+  OUTPUT=$(cmake-lint --config-files cmake/config.json ${RAPIDS_CMAKE_FORMAT_FILE} -- "${@:2}")
   status=$?
 
   if ! [ ${status} -eq 0 ]; then


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/135

Adds `shellcheck` to `pre-commit`, to catch issues like unsafe access patterns, unused variables, etc. in shell scripts.

Fixes these warnings:

```text
SC2046 (warning): Quote this to prevent word splitting.
SC2068 (error): Double quote array expansions to avoid re-splitting elements
```

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [x] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
