### PR TITLE
Use arrow to read parquet metadata

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -76,6 +76,18 @@ rapids_find_package(
   INSTALL_EXPORT_SET LegateDataframe-exports
 )
 
+rapids_find_package(
+  Arrow REQUIRED
+  BUILD_EXPORT_SET LegateDataframe-exports
+  INSTALL_EXPORT_SET LegateDataframe-exports
+)
+
+rapids_find_package(
+  Parquet REQUIRED
+  BUILD_EXPORT_SET LegateDataframe-exports
+  INSTALL_EXPORT_SET LegateDataframe-exports
+)
+
 # add third party dependencies using CPM
 rapids_cpm_init()
 
@@ -123,7 +135,10 @@ target_include_directories(
   INTERFACE "$<INSTALL_INTERFACE:include>"
 )
 
-target_link_libraries(LegateDataframe PUBLIC legate::legate rmm::rmm cudf::cudf)
+target_link_libraries(
+  LegateDataframe PUBLIC legate::legate rmm::rmm cudf::cudf Arrow::arrow_shared
+                         Parquet::parquet_shared
+)
 
 # Add Conda library, and include paths if specified
 if(TARGET conda_env)

--- a/cpp/include/legate_dataframe/utils.hpp
+++ b/cpp/include/legate_dataframe/utils.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023-2024, NVIDIA CORPORATION.
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,19 +20,38 @@
 
 #include <legate.h>
 
+#include <arrow/type.h>
 #include <cudf/column/column_view.hpp>
 #include <cudf/types.hpp>
 
 namespace legate::dataframe {
 
 cudf::type_id to_cudf_type_id(legate::Type::Code code);
+cudf::data_type to_cudf_type(const arrow::DataType& arrow_type);
 legate::Type to_legate_type(cudf::type_id dtype);
+
 std::string pprint_1d(cudf::column_view col,
                       cudf::size_type index,
                       rmm::cuda_stream_view stream,
                       rmm::mr::device_memory_resource* mr);
+
 const void* read_accessor_as_1d_bytes(const legate::PhysicalStore& store);
+
 std::vector<legate::PhysicalStore> get_stores(const legate::PhysicalArray& ary);
+
+/**
+ * @brief Helper unpack an arrow result or throw an exception
+ *
+ * @tparam T The type of the result
+ * @param result The Arrow result to convert
+ * @return The result
+ */
+template <typename T>
+T ARROW_RESULT(arrow::Result<T> result)
+{
+  if (!result.ok()) { throw std::runtime_error(result.status().ToString()); }
+  return std::move(result).ValueOrDie();
+}
 
 /**
  * @brief Parse a UNIX glob string incl. tilde expansion

--- a/cpp/src/parquet.cpp
+++ b/cpp/src/parquet.cpp
@@ -19,6 +19,12 @@
 #include <stdexcept>
 #include <vector>
 
+#include <arrow/io/file.h>
+#include <arrow/io/memory.h>
+#include <parquet/arrow/reader.h>
+#include <parquet/arrow/schema.h>
+#include <parquet/file_reader.h>
+
 #include <cudf/concatenate.hpp>
 #include <cudf/io/parquet.hpp>
 #include <cudf/unary.hpp>
@@ -31,6 +37,7 @@
 #include <legate_dataframe/core/table.hpp>
 #include <legate_dataframe/core/task_context.hpp>
 #include <legate_dataframe/core/transposed_copy.cuh>
+#include <legate_dataframe/utils.hpp>
 
 #include <legate_dataframe/parquet.hpp>
 
@@ -219,9 +226,10 @@ const auto reg_id_ = []() -> char {
 struct ParquetReadInfo {
   std::vector<std::string> file_paths;
   std::vector<std::string> column_names;
+  std::vector<cudf::data_type> column_types;
+  std::vector<bool> column_nullable;
   std::vector<size_t> nrows;
   size_t nrows_total;
-  std::unique_ptr<cudf::table> prototype_table;
 };
 
 ParquetReadInfo get_parquet_info(const std::string& glob_string,
@@ -229,28 +237,54 @@ ParquetReadInfo get_parquet_info(const std::string& glob_string,
 {
   std::vector<std::string> file_paths = parse_glob(glob_string);
   if (file_paths.empty()) { throw std::invalid_argument("no parquet files specified"); }
-  // We read the meta data from the first file
-  auto source  = cudf::io::source_info(file_paths[0]);
-  auto options = cudf::io::parquet_reader_options::builder(source).num_rows(1);
-  if (columns.has_value()) { options.columns(columns.value()); }
-  auto result = cudf::io::read_parquet(options);
 
-  // Get the column names
-  std::vector<std::string> column_names;
-  column_names.reserve(result.metadata.schema_info.size());
-  for (const auto& column_name_info : result.metadata.schema_info) {
-    column_names.push_back(column_name_info.name);
+  // TODO: Using the default memory pool, hopefully it doesn't matter anyway here.
+  auto pool = arrow::default_memory_pool();
+
+  // Open the first file to get schema information
+  auto reader = ARROW_RESULT(arrow::io::ReadableFile::Open(file_paths[0]));
+
+  // Newer versions arrow have versions that return a result which is more convenient...
+  std::unique_ptr<parquet::arrow::FileReader> parquet_reader;
+  auto status = parquet::arrow::OpenFile(reader, pool, &parquet_reader);
+  if (!status.ok()) {
+    throw std::runtime_error("failed to open parquet file: " + status.ToString());
+  }
+  std::shared_ptr<arrow::Schema> schema;
+  status = parquet_reader->GetSchema(&schema);
+  if (!status.ok()) { throw std::runtime_error("failed to get schema: " + status.ToString()); }
+
+  std::optional<std::set<std::string>> requested_names;
+  if (columns.has_value()) {
+    requested_names = std::set<std::string>(columns.value().begin(), columns.value().end());
   }
 
-  // Get the number of rows in each file:
+  // Get the column names from the schema
+  std::vector<std::string> column_names;
+  std::vector<cudf::data_type> column_types;
+  std::vector<bool> column_nullable;
+  column_names.reserve(schema->num_fields());
+  column_types.reserve(schema->num_fields());
+  column_nullable.reserve(schema->num_fields());
+  for (int i = 0; i < schema->num_fields(); i++) {
+    auto name = schema->field(i)->name();
+    if (requested_names.has_value() && requested_names->count(name) == 0) { continue; }
+    column_names.emplace_back(name);
+    auto arrow_type = schema->field(i)->type();
+    column_types.emplace_back(to_cudf_type(*arrow_type.get()));
+    column_nullable.emplace_back(schema->field(i)->nullable());
+  }
+
+  // Get the number of rows in each file
   std::vector<size_t> nrows;
   size_t nrows_total = 0;
   nrows.reserve(file_paths.size());
   for (const auto& path : file_paths) {
-    auto source   = cudf::io::source_info(path);
-    auto metadata = cudf::io::read_parquet_metadata(source);
-    nrows.push_back(metadata.num_rows());
-    nrows_total += metadata.num_rows();
+    auto reader         = ARROW_RESULT(arrow::io::ReadableFile::Open(path));
+    auto parquet_reader = parquet::ParquetFileReader::Open(reader);
+    auto metadata       = parquet_reader->metadata();
+    nrows.push_back(metadata->num_rows());
+    nrows_total += metadata->num_rows();
   }
 
   // Validate column names if specified
@@ -265,9 +299,10 @@ ParquetReadInfo get_parquet_info(const std::string& glob_string,
 
   return {std::move(file_paths),
           std::move(column_names),
+          std::move(column_types),
+          std::move(column_nullable),
           std::move(nrows),
-          nrows_total,
-          std::move(result.tbl)};
+          nrows_total};
 }
 
 }  // namespace
@@ -290,8 +325,15 @@ void parquet_write(LogicalTable& tbl, const std::string& dirpath)
 LogicalTable parquet_read(const std::string& glob_string,
                           const std::optional<std::vector<std::string>>& columns)
 {
-  auto info        = get_parquet_info(glob_string, columns);
-  LogicalTable ret = LogicalTable::empty_like(*info.prototype_table, info.column_names);
+  auto info = get_parquet_info(glob_string, columns);
+
+  std::vector<LogicalColumn> logical_columns;
+  logical_columns.reserve(info.column_types.size());
+  for (int i = 0; i < info.column_types.size(); i++) {
+    logical_columns.emplace_back(
+      LogicalColumn::empty_like(info.column_types.at(i), info.column_nullable.at(i), false));
+  }
+  auto ret = LogicalTable(std::move(logical_columns), info.column_names);
 
   auto runtime = legate::Runtime::get_runtime();
   legate::AutoTask task =
@@ -317,12 +359,12 @@ legate::LogicalArray parquet_read_array(const std::string& glob_string,
   legate::Type legate_type = legate::null_type();
 
   if (!type.has_value()) {
-    auto cudf_type = info.prototype_table->get_column(0).type();
+    auto cudf_type = info.column_types.at(0);
     if (!cudf::is_numeric(cudf_type)) {
       throw std::invalid_argument("only numeric columns are supported for parquet_read_array");
     }
-    for (auto&& col : info.prototype_table->view()) {
-      if (col.type().id() != cudf_type.id()) {
+    for (auto& type : info.column_types) {
+      if (type.id() != type.id()) {
         throw std::invalid_argument("all columns must have the same type");
       }
     }
@@ -332,17 +374,24 @@ legate::LogicalArray parquet_read_array(const std::string& glob_string,
     legate_type = type.value();
 
     auto cudf_type = cudf::data_type{to_cudf_type_id(legate_type.code())};
-    for (auto&& col : info.prototype_table->view()) {
-      if (!cudf::is_supported_cast(col.type(), cudf_type)) {
+    for (auto& type : info.column_types) {
+      if (!cudf::is_supported_cast(type, cudf_type)) {
         throw std::invalid_argument("Cannot cast all columns to specified type");
       }
     }
   }
 
-  auto nullable = null_value.type().code() == Type::Code::NIL;
-  if (!nullable) {
-    if (null_value.type() != legate_type) {
-      throw std::invalid_argument("null value must be null or have the same type as the result");
+  // If all columns are not nullable, we don't have to worry about null values
+  auto nullable = std::any_of(info.column_nullable.begin(),
+                              info.column_nullable.end(),
+                              [](bool nullable) { return nullable; });
+  if (nullable) {
+    // Otherwise, see if we fill the null values
+    nullable = null_value.type().code() == Type::Code::NIL;
+    if (!nullable) {
+      if (null_value.type() != legate_type) {
+        throw std::invalid_argument("null value must be null or have the same type as the result");
+      }
     }
   }
 

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -106,6 +106,49 @@ cudf::type_id to_cudf_type_id(legate::Type::Code code)
   }
 }
 
+cudf::data_type to_cudf_type(const arrow::DataType& arrow_type)
+{
+  switch (arrow_type.id()) {
+    case arrow::Type::BOOL: {
+      return cudf::data_type{cudf::type_id::BOOL8};
+    }
+    case arrow::Type::INT8: {
+      return cudf::data_type{cudf::type_id::INT8};
+    }
+    case arrow::Type::INT16: {
+      return cudf::data_type{cudf::type_id::INT16};
+    }
+    case arrow::Type::INT32: {
+      return cudf::data_type{cudf::type_id::INT32};
+    }
+    case arrow::Type::INT64: {
+      return cudf::data_type{cudf::type_id::INT64};
+    }
+    case arrow::Type::UINT8: {
+      return cudf::data_type{cudf::type_id::UINT8};
+    }
+    case arrow::Type::UINT16: {
+      return cudf::data_type{cudf::type_id::UINT16};
+    }
+    case arrow::Type::UINT32: {
+      return cudf::data_type{cudf::type_id::UINT32};
+    }
+    case arrow::Type::UINT64: {
+      return cudf::data_type{cudf::type_id::UINT64};
+    }
+    case arrow::Type::FLOAT: {
+      return cudf::data_type{cudf::type_id::FLOAT32};
+    }
+    case arrow::Type::DOUBLE: {
+      return cudf::data_type{cudf::type_id::FLOAT64};
+    }
+    case arrow::Type::STRING: {
+      return cudf::data_type{cudf::type_id::STRING};
+    }
+    default: throw std::invalid_argument("unsupported Arrow datatype");
+  }
+}
+
 legate::Type to_legate_type(cudf::type_id dtype)
 {
   switch (dtype) {

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -145,6 +145,21 @@ cudf::data_type to_cudf_type(const arrow::DataType& arrow_type)
     case arrow::Type::STRING: {
       return cudf::data_type{cudf::type_id::STRING};
     }
+    case arrow::Type::DATE64: {
+      return cudf::data_type{cudf::type_id::TIMESTAMP_MILLISECONDS};
+    }
+    case arrow::Type::DURATION: {
+      const auto& duration_type = static_cast<const arrow::DurationType&>(arrow_type);
+      if (duration_type.unit() == arrow::TimeUnit::SECOND) {
+        return cudf::data_type{cudf::type_id::DURATION_SECONDS};
+      } else if (duration_type.unit() == arrow::TimeUnit::MILLI) {
+        return cudf::data_type{cudf::type_id::DURATION_MILLISECONDS};
+      } else if (duration_type.unit() == arrow::TimeUnit::MICRO) {
+        return cudf::data_type{cudf::type_id::DURATION_MICROSECONDS};
+      } else if (duration_type.unit() == arrow::TimeUnit::NANO) {
+        return cudf::data_type{cudf::type_id::DURATION_NANOSECONDS};
+      }
+    }
     default: throw std::invalid_argument("unsupported Arrow datatype");
   }
 }


### PR DESCRIPTION
This uses arrows parquet reader to read the metadata from the file.  This will need
a little bit of polishing for odder data types

A wrinkle is that the dtype conversion is certainly not complete (and also note tested for all types here).

Should address the hopefully larger issue in gh-47, it will still decompress too much data and use a larger memory overhead with large row group chunk sizes.

(Not sure the CI will build, I think we effectively pull in arrow via cudf, but we should have it as an explicit dependency with gh-53.)