### PR TITLE
BUG: Fix offset for and add sanity check to maybe_bind_buffer

### DIFF
--- a/cpp/src/core/column.cu
+++ b/cpp/src/core/column.cu
@@ -142,7 +142,9 @@ T* maybe_bind_buffer(legate::PhysicalStore store, std::size_t size)
   if (store.is_unbound_store()) {
     out = store.create_output_buffer<T, 1>(legate::Point<1>(size), true).ptr(0);
   } else {
-    out = store.write_accessor<T, 1>().ptr(0);
+    auto acc = store.write_accessor<T, 1>();
+    assert(store.shape<1>().hi[0] == -1 || acc.accessor.is_dense_row_major(store.shape<1>()));
+    out = acc.ptr(store.shape<1>().lo[0]);
   }
   return out;
 }


### PR DESCRIPTION
Since it is currently called from outside tasks, this lingering bug probably has no effect (the offset is always 0).

But this was a useful pattern when allowing eager allocations more generally and writing output in gh-57 where this then triggers.

So let's just fix it, even if it may not ever be hit without gh-57.
