### PR TITLE
Fixup parquet chunking

### DIFF
--- a/cpp/src/parquet.cpp
+++ b/cpp/src/parquet.cpp
@@ -224,9 +224,9 @@ class ParquetReadArray : public Task<ParquetReadArray, OpCode::ParquetReadArray>
     auto [files, row_groups] =
       find_files_and_row_groups(file_paths, ngroups_per_file, my_groups_offset, my_num_groups);
 
-    // Read a few hundred MiB at a time (assumes datatype isn't very narrow).
-    // (The actual decompression etc. will be done in larger chunks.)
-    auto chunksize = ((1 << 25) + ncols - 1) / ncols;
+    // Read a few hundred MiB at a time (actual limit is a multiple due to decompression
+    // and that may also just need more memory as well, there may be other components).
+    auto chunksize = 500 * 1024 * 1024;
 
     auto src = cudf::io::source_info(files);
     auto opt = cudf::io::parquet_reader_options::builder(src);


### PR DESCRIPTION
The old value didn't make sense, this should be in bytes. (I doubt this makes a difference, since the old value should just have been too small.)

https://docs.rapids.ai/api/libcudf/stable/classcudf_1_1io_1_1chunked__parquet__reader#a49f5549b53257828d50f5fa65114e07a
