### PR TITLE
MAINT,BUG: Indicate that we are using the task stream and side-effect

### DIFF
--- a/cpp/src/core/library.cpp
+++ b/cpp/src/core/library.cpp
@@ -133,7 +133,8 @@ legate::Library create_and_registrate_library()
     }
   }
   // Set with_has_allocations globally since currently all tasks allocate (and libcudf may also)
-  auto options = legate::VariantOptions{}.with_has_allocations(true);
+  auto options =
+    legate::VariantOptions{}.with_has_allocations(true).with_elide_device_ctx_sync(true);
   auto context = runtime->find_or_create_library(library_name,
                                                  legate::ResourceConfig{},
                                                  std::make_unique<Mapper>(),

--- a/cpp/src/csv.cpp
+++ b/cpp/src/csv.cpp
@@ -41,6 +41,11 @@ class CSVWrite : public Task<CSVWrite, OpCode::CSVWrite> {
  public:
   static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{OpCode::CSVWrite}};
 
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
+                                                .with_has_allocations(true)
+                                                .with_elide_device_ctx_sync(true)
+                                                .with_has_side_effect(true);
+
   static void cpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};

--- a/cpp/src/groupby_aggregation.cpp
+++ b/cpp/src/groupby_aggregation.cpp
@@ -38,8 +38,10 @@ class GroupByAggregationTask : public Task<GroupByAggregationTask, OpCode::Group
   static inline const auto TASK_CONFIG =
     legate::TaskConfig{legate::LocalTaskID{OpCode::GroupByAggregation}};
 
-  static constexpr auto GPU_VARIANT_OPTIONS =
-    legate::VariantOptions{}.with_has_allocations(true).with_concurrent(true);
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
+                                                .with_has_allocations(true)
+                                                .with_concurrent(true)
+                                                .with_elide_device_ctx_sync(true);
 
   static void gpu_variant(legate::TaskContext context)
   {

--- a/cpp/src/join.cpp
+++ b/cpp/src/join.cpp
@@ -201,8 +201,10 @@ class JoinTask : public Task<JoinTask, OpCode::Join> {
  public:
   static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{OpCode::Join}};
 
-  static constexpr auto GPU_VARIANT_OPTIONS =
-    legate::VariantOptions{}.with_has_allocations(true).with_concurrent(true);
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
+                                                .with_has_allocations(true)
+                                                .with_concurrent(true)
+                                                .with_elide_device_ctx_sync(true);
 
   static void gpu_variant(legate::TaskContext context)
   {

--- a/cpp/src/parquet.cpp
+++ b/cpp/src/parquet.cpp
@@ -48,6 +48,11 @@ class ParquetWrite : public Task<ParquetWrite, OpCode::ParquetWrite> {
   static inline const auto TASK_CONFIG =
     legate::TaskConfig{legate::LocalTaskID{OpCode::ParquetWrite}};
 
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
+                                                .with_has_allocations(true)
+                                                .with_elide_device_ctx_sync(true)
+                                                .with_has_side_effect(true);
+
   static void gpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};

--- a/cpp/src/sort.cpp
+++ b/cpp/src/sort.cpp
@@ -311,8 +311,10 @@ class SortTask : public Task<SortTask, OpCode::Sort> {
  public:
   static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{OpCode::Sort}};
 
-  static constexpr auto GPU_VARIANT_OPTIONS =
-    legate::VariantOptions{}.with_has_allocations(true).with_concurrent(true);
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
+                                                .with_has_allocations(true)
+                                                .with_concurrent(true)
+                                                .with_elide_device_ctx_sync(true);
 
   static void gpu_variant(legate::TaskContext context)
   {


### PR DESCRIPTION
Based on guidance from the legate team, add the `with_elide_device_ctx_sync` to indicate to realm that we are using the task stream. This should still guarantee correct sychronization for output tasks because sychronization still happens, we just indicate that we do use the task stream and thus synching that is sufficient.

We also should indicate that the output csv/parquet writer tasks have side effects.  In practice, I don't think we hit any problems due to it, but it is just correct (e.g. gh-64 is unrelated).

Closes gh-66