### PR TITLE
Implement limit to sorting

### DIFF
--- a/cpp/include/legate_dataframe/sort.hpp
+++ b/cpp/include/legate_dataframe/sort.hpp
@@ -37,12 +37,15 @@ namespace legate::dataframe {
  * @param sort_ascending Whether to sort ascending or descending for each key.
  * @param nulls_at_end Whether nulls are placed at the begging or end (regardless of ascending or
  * descending sort).
+ * @param limit The maximum number of rows to return. If negative, the last rows
+ * are returns (i.e. a head/tail operation).
  * @return The sorted LogicalTable
  */
 LogicalTable sort(const LogicalTable& tbl,
                   const std::vector<std::string>& keys,
                   const std::vector<bool>& sort_ascending,
                   bool nulls_at_end,
-                  bool stable = false);
+                  bool stable                  = false,
+                  std::optional<int64_t> limit = std::nullopt);
 
 }  // namespace legate::dataframe

--- a/python/legate_dataframe/ldf_polars/dsl/ir.py
+++ b/python/legate_dataframe/ldf_polars/dsl/ir.py
@@ -1137,12 +1137,24 @@ class Sort(IR):
             raise NotImplementedError("Sort keys must be named expressions currently")
         by_names = [key.name for key in by]
 
+        if zlice is None:
+            limit = None
+        elif zlice[0] < 0:
+            # Assume the best slice is slicing from the end
+            limit = zlice[0]
+        else:
+            if zlice[1] is None:
+                limit = None
+            else:
+                limit = zlice[0] + zlice[1]
+
         table = sort.sort(
             df.table,
             by_names,
             sort_ascending=list(sort_ascending),
             nulls_at_end=nulls_at_end,
             stable=stable,
+            limit=limit,
         )
 
         # TODO: should implement simple zlices into sorting probably.

--- a/python/legate_dataframe/lib/sort.pyi
+++ b/python/legate_dataframe/lib/sort.pyi
@@ -9,7 +9,8 @@ def sort(
     tbl: LogicalTable,
     keys: list[str],
     *,
-    sort_ascending: list[bool] | None,
+    sort_ascending: list[bool] | None = None,
     nulls_at_end: bool = True,
-    stable: bool,
+    stable: bool = False,
+    limit: int | None = None,
 ) -> LogicalTable: ...

--- a/python/legate_dataframe/lib/sort.pyx
+++ b/python/legate_dataframe/lib/sort.pyx
@@ -5,7 +5,9 @@
 # cython: language_level=3
 
 
+from libc.stdint cimport int64_t
 from libcpp cimport bool as cpp_bool
+from libcpp.optional cimport optional
 from libcpp.string cimport string
 from libcpp.vector cimport vector
 
@@ -21,6 +23,7 @@ cdef extern from "<legate_dataframe/sort.hpp>" nogil:
         const vector[cpp_bool]& sort_ascending,
         cpp_bool nulls_at_end,
         cpp_bool stable,
+        optional[int64_t] limit,
     ) except +
 
 
@@ -32,6 +35,7 @@ def sort(
     list sort_ascending = None,
     nulls_at_end = True,
     stable = False,
+    limit = None
 ):
     """Perform a sort of the table based on the given columns.
 
@@ -56,6 +60,9 @@ def sort(
     stable
         Whether to perform a stable sort (default ``False``).  Stable sort currently
         uses a less efficient merge and may not perform as well as it should.
+    limit
+        Maximum number of rows to return. If positive, returns the first, if negative
+        the last. (In a distributed setting, this reduces the amount of data exchanged.)
 
     Returns
     -------
@@ -65,14 +72,19 @@ def sort(
     cdef vector[string] keys_vector
     cdef vector[cpp_bool] c_sort_ascending
     cdef cpp_bool c_nulls_at_end = nulls_at_end
+    cdef optional[int64_t] cpp_limit
 
     if sort_ascending is None:
         c_sort_ascending = [True] * len(keys)
     else:
         c_sort_ascending = sort_ascending
 
+    if limit is not None:
+        cpp_limit = <int64_t>limit
+
     for k in keys:
         keys_vector.push_back(k.encode('UTF-8'))
 
-    return LogicalTable.from_handle(
-        cpp_sort(tbl._handle, keys_vector, c_sort_ascending, c_nulls_at_end, stable))
+    return LogicalTable.from_handle(cpp_sort(
+        tbl._handle, keys_vector, c_sort_ascending, c_nulls_at_end, stable, cpp_limit
+    ))


### PR DESCRIPTION
Adds `limit=` to sorting, since at least until we have `top/bottom_k` like functionality, a head/tail call lowered into sorting means a much easier task for a distributed sort.
(once we have `top_k` via [libcudf](https://github.com/rapidsai/cudf/issues/19096), I am not certain that there would be much of a niche left for this.)