### PR TITLE
ENH: Allow ingesting arrow large strings and fix timedelta/datetime roundtrip

### DIFF
--- a/ci/run_pytests_cpu.sh
+++ b/ci/run_pytests_cpu.sh
@@ -28,5 +28,5 @@ legate \
     . \
     -sv \
     --durations=0 \
-    -k 'csv or binary or parquet or replace or unary or reduction' \
+    -k 'csv or binary or parquet or replace or unary or reduction or arrow' \
     "${@}"

--- a/cpp/include/legate_dataframe/core/ranges.hpp
+++ b/cpp/include/legate_dataframe/core/ranges.hpp
@@ -55,6 +55,16 @@ namespace legate::dataframe {
 void arrow_offsets_to_local_ranges(const arrow::StringArray& array, legate::Rect<1>* ranges_acc);
 
 /**
+ * @brief Converts the offsets from an Arrow LargeStringArray into local ranges.
+ *
+ * @param array The Arrow LargeStringArray containing the string data and offsets.
+ * @param ranges_acc Pointer to an array of legate::Rect<1> where the computed ranges will be
+ * stored.
+ */
+void arrow_offsets_to_local_ranges(const arrow::LargeStringArray& array,
+                                   legate::Rect<1>* ranges_acc);
+
+/**
  * @brief Convert local offsets (cudf) to local ranges (legate)
  *
  * @param ranges_size The size of the local ranges accessed through `ranges_acc`.

--- a/cpp/include/legate_dataframe/utils.hpp
+++ b/cpp/include/legate_dataframe/utils.hpp
@@ -27,11 +27,16 @@
 
 namespace legate::dataframe {
 
-cudf::type_id to_cudf_type_id(legate::Type::Code code);
-std::shared_ptr<arrow::DataType> to_arrow_type(cudf::type_id code);
-cudf::data_type to_cudf_type(const arrow::DataType& arrow_type);
-legate::Type to_legate_type(cudf::type_id dtype);
-legate::Type to_legate_type(const arrow::DataType& arrow_type);
+[[nodiscard]] cudf::type_id to_cudf_type_id(legate::Type::Code code);
+[[nodiscard]] std::shared_ptr<arrow::DataType> to_arrow_type(cudf::type_id code);
+[[nodiscard]] cudf::data_type to_cudf_type(const arrow::DataType& arrow_type);
+[[nodiscard]] inline cudf::data_type to_cudf_type(
+  const std::shared_ptr<arrow::DataType>& arrow_type)
+{
+  return to_cudf_type(*arrow_type);
+}
+[[nodiscard]] legate::Type to_legate_type(cudf::type_id dtype);
+[[nodiscard]] legate::Type to_legate_type(const arrow::DataType& arrow_type);
 
 std::string pprint_1d(cudf::column_view col,
                       cudf::size_type index,

--- a/cpp/src/core/column.cu
+++ b/cpp/src/core/column.cu
@@ -234,7 +234,7 @@ void from_arrow(legate::PhysicalArray array, std::shared_ptr<arrow::Array> arrow
 }
 
 // Copy an arrow array into a logical array
-legate::LogicalArray from_arrow(std::shared_ptr<arrow::Array> arrow_array)
+legate::LogicalArray from_arrow(std::shared_ptr<arrow::Array> arrow_array, bool scalar = false)
 {
   // Create an unbound logical array
   auto runtime = legate::Runtime::get_runtime();
@@ -280,7 +280,7 @@ LogicalColumn::LogicalColumn(const cudf::scalar& cudf_scalar, rmm::cuda_stream_v
 LogicalColumn::LogicalColumn(std::shared_ptr<arrow::Array> arrow_array)
   : LogicalColumn{// This type conversion monstrosity can be improved
                   from_arrow(arrow_array),
-                  cudf::data_type(to_cudf_type_id(to_legate_type(*arrow_array->type()).code())),
+                  to_cudf_type(arrow_array->type()),
                   /* scalar */ false}
 {
 }
@@ -288,7 +288,7 @@ LogicalColumn::LogicalColumn(std::shared_ptr<arrow::Array> arrow_array)
 LogicalColumn::LogicalColumn(std::shared_ptr<arrow::Scalar> arrow_scalar)
   : LogicalColumn{// This type conversion monstrosity can be improved
                   from_arrow(arrow_scalar),
-                  cudf::data_type(to_cudf_type_id(to_legate_type(*arrow_scalar->type).code())),
+                  to_cudf_type(arrow_scalar->type),
                   /* scalar */ true}
 {
 }

--- a/cpp/src/core/ranges.cu
+++ b/cpp/src/core/ranges.cu
@@ -127,6 +127,15 @@ void arrow_offsets_to_local_ranges(const arrow::StringArray& array, legate::Rect
   }
 }
 
+void arrow_offsets_to_local_ranges(const arrow::LargeStringArray& array,
+                                   legate::Rect<1>* ranges_acc)
+{
+  for (size_t i = 0; i < array.length(); ++i) {
+    ranges_acc[i].lo[0] = array.value_offset(i);
+    ranges_acc[i].hi[0] = array.value_offset(i + 1) - 1;
+  }
+}
+
 namespace {
 /**
  * @brief CUDA kernel to convert offsets (cudf) to ranges (legate)

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -145,6 +145,9 @@ cudf::data_type to_cudf_type(const arrow::DataType& arrow_type)
     case arrow::Type::STRING: {
       return cudf::data_type{cudf::type_id::STRING};
     }
+    case arrow::Type::LARGE_STRING: {
+      return cudf::data_type{cudf::type_id::STRING};
+    }
     case arrow::Type::DATE64: {
       return cudf::data_type{cudf::type_id::TIMESTAMP_MILLISECONDS};
     }
@@ -159,11 +162,25 @@ cudf::data_type to_cudf_type(const arrow::DataType& arrow_type)
       } else if (duration_type.unit() == arrow::TimeUnit::NANO) {
         return cudf::data_type{cudf::type_id::DURATION_NANOSECONDS};
       }
+      break;
     }
-    default:
-      throw std::invalid_argument("Converting arrow type to cudf failed for type: " +
-                                  arrow_type.ToString());
+    case arrow::Type::TIMESTAMP: {
+      const auto& duration_type = static_cast<const arrow::DurationType&>(arrow_type);
+      if (duration_type.unit() == arrow::TimeUnit::SECOND) {
+        return cudf::data_type{cudf::type_id::TIMESTAMP_SECONDS};
+      } else if (duration_type.unit() == arrow::TimeUnit::MILLI) {
+        return cudf::data_type{cudf::type_id::TIMESTAMP_MILLISECONDS};
+      } else if (duration_type.unit() == arrow::TimeUnit::MICRO) {
+        return cudf::data_type{cudf::type_id::TIMESTAMP_MICROSECONDS};
+      } else if (duration_type.unit() == arrow::TimeUnit::NANO) {
+        return cudf::data_type{cudf::type_id::TIMESTAMP_NANOSECONDS};
+      }
+      break;
+    }
+    default: break;
   }
+  throw std::invalid_argument("Converting arrow type to cudf failed for type: " +
+                              arrow_type.ToString());
 }
 
 legate::Type to_legate_type(cudf::type_id dtype)

--- a/cpp/src/utils.cpp
+++ b/cpp/src/utils.cpp
@@ -287,6 +287,9 @@ legate::Type to_legate_type(const arrow::DataType& arrow_type)
     case arrow::Type::STRING: {
       return legate::string_type();
     }
+    case arrow::Type::LARGE_STRING: {
+      return legate::string_type();
+    }
     case arrow::Type::DURATION: {
       return legate::int64();
     }

--- a/python/tests/test_arrow.py
+++ b/python/tests/test_arrow.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pyarrow as pa
+import pytest
+
+from legate_dataframe import LogicalColumn
+
+example_arrays = [
+    pa.array([True, False, True], type=pa.bool_()),
+    pa.array([1, 2, 3], type=pa.int32()),
+    pa.array([1, 2, 3], type=pa.int64()),
+    pa.array([1, 2, 3], type=pa.uint32()),
+    pa.array([1, 2, 3], type=pa.uint64()),
+    pa.array([1, 2, 3], type=pa.float32()),
+    pa.array([1, 2, 3], type=pa.float64()),
+    pa.array(["1", "2", "3"], type=pa.string()),
+    pa.array(["1", "2", "3"], type=pa.large_string()),
+    # Times:
+    pa.array([1, 2, 3], type=pa.timestamp("s")),
+    pa.array([1, 2, 3], type=pa.timestamp("ms")),
+    pa.array([1, 2, 3], type=pa.timestamp("us")),
+    pa.array([1, 2, 3], type=pa.timestamp("ns")),
+    pa.array([1, 2, 3], type=pa.duration("s")),
+    pa.array([1, 2, 3], type=pa.duration("ms")),
+    pa.array([1, 2, 3], type=pa.duration("us")),
+    pa.array([1, 2, 3], type=pa.duration("ns")),
+]
+
+
+@pytest.mark.parametrize("array", example_arrays)
+def test_column_round_trip(array):
+    expected = array
+    if array.type == pa.large_string():
+        # If the input is a large string, it's OK to round-trp to string
+        expected = pa.array(expected, type=pa.string())
+    assert expected == LogicalColumn.from_arrow(array).to_arrow()
+
+    array = pa.array(array, mask=[True, False, True])
+    expected = pa.array(expected, mask=[True, False, True])
+    assert expected == LogicalColumn.from_arrow(array).to_arrow()
+
+
+@pytest.mark.parametrize("array", example_arrays)
+def test_scalar_round_trip(array):
+    scalar = array[0]
+    # to_arrow() returns an array (but we do preserve the scalar info)
+    expected = array[:1]
+    if array.type == pa.large_string():
+        # If the input is a large string, it's OK to round-trp to string
+        expected = pa.array(expected, type=pa.string())
+
+    col = LogicalColumn.from_arrow(scalar)
+    assert col.is_scalar()
+    assert expected == col.to_arrow()


### PR DESCRIPTION
Does not yet use them when our strings are larger than 2GiB. I need this for polars interop because polars tends to create large strings (probably just always).
(So tested there, but not here, but I guess we could add explicit arrow round-trip tests.)

Basically, just duplicating.  Templating didn't seem much better considering how short the snippets were, but if you have an idea, happy to change.