### PR TITLE
Support logical operators (again) and in_between for polars

### DIFF
--- a/python/legate_dataframe/ldf_polars/dsl/expressions/binaryop.py
+++ b/python/legate_dataframe/ldf_polars/dsl/expressions/binaryop.py
@@ -52,12 +52,10 @@ class BinOp(Expr):
         #     )
 
     _BOOL_KLEENE_MAPPING: ClassVar[dict[plc.binaryop.BinaryOperator, str]] = {
-        # Commented out ones are currently unsupported on the C-side or not clearly mapped
-        # due to nullable handling (also below)
-        # plc.binaryop.BinaryOperator.BITWISE_AND: plc.binaryop.BinaryOperator.NULL_LOGICAL_AND,
-        # plc.binaryop.BinaryOperator.BITWISE_OR: plc.binaryop.BinaryOperator.NULL_LOGICAL_OR,
-        # plc.binaryop.BinaryOperator.LOGICAL_AND: plc.binaryop.BinaryOperator.NULL_LOGICAL_AND,
-        # plc.binaryop.BinaryOperator.LOGICAL_OR: plc.binaryop.BinaryOperator.NULL_LOGICAL_OR,
+        "bit_wise_and": "and_kleene",
+        "bit_wise_or": "or_kleene",
+        "and": "and_kleene",
+        "or": "or_kleene",
     }
 
     _MAPPING: ClassVar[dict[pl_expr.Operator, str]] = {
@@ -79,8 +77,8 @@ class BinOp(Expr):
         pl_expr.Operator.And: "bit_wise_and",
         pl_expr.Operator.Or: "bit_wise_or",
         pl_expr.Operator.Xor: "bit_wise_xor",
-        # pl_expr.Operator.LogicalAnd: plc.binaryop.BinaryOperator.LOGICAL_AND,
-        # pl_expr.Operator.LogicalOr: plc.binaryop.BinaryOperator.LOGICAL_OR,
+        pl_expr.Operator.LogicalAnd: "and",
+        pl_expr.Operator.LogicalOr: "or",
     }
 
     def do_evaluate(

--- a/python/tests/test_binaryop.py
+++ b/python/tests/test_binaryop.py
@@ -28,6 +28,18 @@ from legate_dataframe.testing import (
 )
 
 ops = ["add", "subtract", "multiply"]
+ops_bool = [
+    "and",
+    "or",
+    "and_kleene",
+    "or_kleene",
+    "equal",
+    "not_equal",
+    "less",
+    "less_equal",
+    "greater",
+    "greater_equal",
+]
 
 
 @pytest.mark.parametrize("op", ops)
@@ -39,6 +51,18 @@ def test_arithmetic_operations(op: str):
 
     res = binary_operation(lg_a, lg_b, op, np.float64)
     expect = pa.compute.call_function(op, [a, b])
+    assert expect == res.to_arrow()
+
+
+@pytest.mark.parametrize("op", ops_bool)
+def test_bool_out_operations(op: str):
+    a = gen_random_series(nelem=1000, num_nans=10)
+    b = gen_random_series(nelem=1000, num_nans=10)
+    lg_a = LogicalColumn.from_arrow(a)
+    lg_b = LogicalColumn.from_arrow(b)
+
+    res = binary_operation(lg_a, lg_b, op, "bool")
+    expect = pa.compute.call_function(op, [a.cast("bool"), b.cast("bool")])
     assert expect == res.to_arrow()
 
 
@@ -78,21 +102,43 @@ def test_scalar_input(array, op, scalar):
     assert result.is_scalar()  # if both inputs are scalar, the result is also
 
 
-operators = ["add", "sub", "mul"]
+operators = ["add", "sub", "mul", "and_", "or_", "eq", "ne", "lt", "le", "gt", "ge"]
 
 
 @pytest.mark.parametrize("op", operators)
 def test_binary_operation_polars(op):
     pl = pytest.importorskip("polars")
-    import legate_dataframe.ldf_polars  # noqa: F401
 
     a = gen_random_series(nelem=1000, num_nans=10)
     b = gen_random_series(nelem=1000, num_nans=10)
+    if op in {"and_", "or_"}:
+        # and_ and or_ are bitwise, and require bool inputs.
+        a = a.cast("bool")
+        b = b.cast("bool")
+
     a_s = pl.from_arrow(a)
     b_s = pl.from_arrow(b)
 
     # Need to work with a lazyframe, as there is no lazy series.
     q = pl.LazyFrame({"a": a_s, "b": b_s}).with_columns(
         a_b=getattr(operator, op)(pl.col("a"), pl.col("b"))
+    )
+    assert_matches_polars(q)
+
+
+@pytest.mark.parametrize("mode", ["none", "left", "right", "both"])
+def test_between_polars(mode):
+    pl = pytest.importorskip("polars")
+
+    a = gen_random_series(nelem=1000, num_nans=10)
+    b = gen_random_series(nelem=1000, num_nans=10)
+    c = gen_random_series(nelem=1000, num_nans=10)
+
+    a_s = pl.from_arrow(a)
+    b_s = pl.from_arrow(b)
+    c_s = pl.from_arrow(c)
+
+    q = pl.LazyFrame({"a": a_s, "b": b_s, "c": c_s}).with_columns(
+        pl.col("a").is_between(pl.col("b"), pl.col("c"), closed=mode)
     )
     assert_matches_polars(q)


### PR DESCRIPTION
This re-adds supports for logical operators, which were missing because arrow seems to require boolean inputs (i.e. an explicit cast).

Additionally, since `in_between` seems commonly used in polars ad support for that again.
(Polars is a bit fun, in that it also only defines bitwise and/or it seems.)

With this, I can run pdsh query 6 (with file limitations).

N.B.: Next steps for pdsh is:
1. Support of multiple files rather than just glob (I am tempted to do the `glob.glob()` part only in Python and change the C++ API to require a vector of files (or single file maybe, although `{filename}` is not that bad).
2. Most queries require groups-by aggs.
3. (depending on how data is generated, data often contains decimals, support for which needs to be added in some paths, but testing with non-decimal files is fine)

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [x] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
