### PR TITLE
API: Allow iterable of files and move globbing to Python for readers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ def main(tmpdir):
     # Then we can read the parquet files back into a logical table. We
     # provide a Glob string that reference all the parquet files that
     # should go into the logical table.
-    tbl2 = parquet_read(glob_string=f"{tmpdir}/*.parquet")
+    tbl2 = parquet_read(f"{tmpdir}/*.parquet")
 
     # LogicalColumn implements the `__legate_data_interface__` interface,
     # which makes it possible for other Legate libraries, such as cuPyNumeric,
@@ -120,6 +120,7 @@ if __name__ == "__main__":
 #include <legate_dataframe/core/table.hpp>
 #include <legate_dataframe/parquet.hpp>
 #include <legate_dataframe/unaryop.hpp>
+#include <legate_dataframe/utils.hpp>
 
 int main(int argc, char** argv)
 {
@@ -151,7 +152,8 @@ int main(int argc, char** argv)
   // Then we can read the parquet files back into a logical table. We
   // provide a Glob string that reference all the parquet files that
   // should go into the logical table.
-  auto tbl_b = legate::dataframe::parquet_read("./my_parquet_file/*.parquet");
+  auto files = legate::dataframe::parse_glob("./my_parquet_file/*.parquet");
+  auto tbl_b = legate::dataframe::parquet_read(files);
 
   // Clean up
   std::filesystem::remove_all("./my_parquet_file");

--- a/cpp/examples/hello.cpp
+++ b/cpp/examples/hello.cpp
@@ -23,6 +23,7 @@
 #include <legate_dataframe/filling.hpp>
 #include <legate_dataframe/parquet.hpp>
 #include <legate_dataframe/unaryop.hpp>
+#include <legate_dataframe/utils.hpp>
 
 int main(void)
 {
@@ -55,7 +56,8 @@ int main(void)
   // Then we can read the parquet files back into a logical table. We
   // provide a Glob string that reference all the parquet files that
   // should go into the logical table.
-  auto tbl_b = legate::dataframe::parquet_read("./my_parquet_file/*.parquet");
+  auto files = legate::dataframe::parse_glob("./my_parquet_file/*.parquet");
+  auto tbl_b = legate::dataframe::parquet_read(files);
 
   // Clean up
   std::filesystem::remove_all("./my_parquet_file");

--- a/cpp/include/legate_dataframe/csv.hpp
+++ b/cpp/include/legate_dataframe/csv.hpp
@@ -59,8 +59,7 @@ void csv_write(LogicalTable& tbl, const std::string& dirpath, char delimiter = '
  * TODO: We should replace some/all params with cudf::io::csv_reader_options eventually.
  *       As if writing, this would be better with pylibcudf 25.02 which cannot be quite used.
  *
- * @param glob_string The glob string to specify the csv files. All glob matches must be valid
- * csv files and have the same layout. See <https://linux.die.net/man/7/glob>.
+ * @param files The csv files to read.
  * @param dtypes The cudf type for each column (must match usecols).
  * @param na_filter Whether to detect missing values, set to false to improve performance.
  * @param delimiter The field delimiter.
@@ -69,7 +68,7 @@ void csv_write(LogicalTable& tbl, const std::string& dirpath, char delimiter = '
  * passing `usecols_idx` without names is not supported.
  * @return The read LogicalTable.
  */
-LogicalTable csv_read(const std::string& glob_string,
+LogicalTable csv_read(const std::vector<std::string>& files,
                       const std::vector<cudf::data_type>& dtypes,
                       bool na_filter                                       = true,
                       char delimiter                                       = ',',

--- a/cpp/include/legate_dataframe/parquet.hpp
+++ b/cpp/include/legate_dataframe/parquet.hpp
@@ -46,19 +46,18 @@ void parquet_write(LogicalTable& tbl, const std::string& dirpath);
  * @brief Read Parquet files into a LogicalTable
  *
  * Files are currently read into N partitions where N is the number of GPU workers used.
- * The partitions are split by row, meaning that each reads approximately the
- * same number of rows (possibly over multiple files).
- * If the number of rows does not split evenly, the first partitions will
- * contain one additional row.
+ * The partitions are split by row-group, meaning that each reads approximately the
+ * same number of row-groups (possibly over multiple files).
+ * If the number of row-groups does not split evenly, the first partitions will
+ * contain one additional row-group.
  *
  * Note that file order is currently glob/string sorted.
  *
- * @param glob_string The glob string to specify the Parquet files. All glob matches must be valid
- * Parquet files and have the same LogicalTable data types. See <https://linux.die.net/man/7/glob>.
+ * @param files The parquet files to read.
  * @param columns The columns names to read.
  * @return The read LogicalTable
  */
-LogicalTable parquet_read(const std::string& glob_string,
+LogicalTable parquet_read(const std::vector<std::string>& files,
                           const std::optional<std::vector<std::string>>& columns = std::nullopt);
 
 /**
@@ -67,13 +66,12 @@ LogicalTable parquet_read(const std::string& glob_string,
  * Note that file order is currently glob/string sorted.  All columns that are being read must have
  * the same type and be compatible with a legate type, currently only numeric types are supported.
  *
- * @param glob_string The glob string to specify the Parquet files. All glob matches must be valid
- * Parquet files and have the same LogicalTable data types. See <https://linux.die.net/man/7/glob>.
+ * @param files The parquet files to read.
  * @param columns The columns names to read.
  * @param nullable If set to ``False``, assume that the file does contain any nulls.
  * @return The read LogicalTable
  */
-legate::LogicalArray parquet_read_array(const std::string& glob_string,
+legate::LogicalArray parquet_read_array(const std::vector<std::string>& files,
                                         const std::optional<std::vector<std::string>>& columns,
                                         const legate::Scalar& null_value,
                                         const std::optional<legate::Type>& type);

--- a/cpp/tests/test_csv.cpp
+++ b/cpp/tests/test_csv.cpp
@@ -47,7 +47,8 @@ TYPED_TEST(NumericCSVTest, ReadWrite)
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
   auto dtype = cudf::data_type{cudf::type_to_id<TypeParam>()};
-  auto tbl_b = csv_read(tmp_dir.path() / "*.csv", {dtype, dtype}, false);
+  auto files = parse_glob(tmp_dir.path() / "*.csv");
+  auto tbl_b = csv_read(files, {dtype, dtype}, false);
 
   EXPECT_TRUE(tbl_a.get_arrow()->Equals(*tbl_b.get_arrow()));
 }
@@ -68,7 +69,8 @@ TYPED_TEST(NumericCSVTest, ReadWriteSingleItem)
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
   auto dtype = cudf::data_type{cudf::type_to_id<TypeParam>()};
-  auto tbl_b = csv_read(tmp_dir.path() / "*.csv", {dtype}, false);
+  auto files = parse_glob(tmp_dir.path() / "*.csv");
+  auto tbl_b = csv_read(files, {dtype}, false);
 
   EXPECT_TRUE(tbl_a.get_arrow()->Equals(*tbl_b.get_arrow()));
 }
@@ -89,7 +91,8 @@ TEST(StringsCSVTest, ReadWrite)
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
   auto dtype = tbl_a.get_column(0).cudf_type();
-  auto tbl_b = csv_read(tmp_dir.path() / "*.csv", {dtype}, false);
+  auto files = parse_glob(tmp_dir.path() / "*.csv");
+  auto tbl_b = csv_read(files, {dtype}, false);
 
   EXPECT_TRUE(tbl_a.get_arrow()->Equals(*tbl_b.get_arrow()));
 }
@@ -109,7 +112,8 @@ TYPED_TEST(NumericCSVTest, ReadNulls)
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
   auto dtype = cudf::data_type{cudf::type_to_id<TypeParam>()};
-  auto tbl_b = csv_read(tmp_dir.path() / "*.csv", {dtype, dtype}, true);
+  auto files = parse_glob(tmp_dir.path() / "*.csv");
+  auto tbl_b = csv_read(files, {dtype, dtype}, true);
 
   EXPECT_TRUE(tbl_a.get_arrow()->Equals(*tbl_b.get_arrow()));
 }
@@ -130,12 +134,13 @@ TYPED_TEST(NumericCSVTest, ReadUseCols)
 
   auto dtype = cudf::data_type{cudf::type_to_id<TypeParam>()};
   std::vector<std::string> usecols1({"a", "b"});
-  auto tbl_b = csv_read(tmp_dir.path() / "*.csv", {dtype, dtype}, true, ',', usecols1);
+  auto files = parse_glob(tmp_dir.path() / "*.csv");
+  auto tbl_b = csv_read(files, {dtype, dtype}, true, ',', usecols1);
 
   EXPECT_TRUE(tbl_a.get_arrow()->Equals(*tbl_b.get_arrow()));
 
   std::vector<std::string> usecols2({"b"});
-  auto tbl_c = csv_read(tmp_dir.path() / "*.csv", {dtype}, true, ',', usecols2);
+  auto tbl_c = csv_read(files, {dtype}, true, ',', usecols2);
 
   LogicalTable tbl_d({b}, {"b"});
   EXPECT_TRUE(tbl_d.get_arrow()->Equals(*tbl_c.get_arrow()));
@@ -157,7 +162,8 @@ TYPED_TEST(NumericCSVTest, ReadWriteWithDelimiter)
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
   auto dtype = cudf::data_type{cudf::type_to_id<TypeParam>()};
-  auto tbl_b = csv_read(tmp_dir.path() / "*.csv", {dtype, dtype}, false, '|');
+  auto files = parse_glob(tmp_dir.path() / "*.csv");
+  auto tbl_b = csv_read(files, {dtype, dtype}, false, '|');
 
   EXPECT_TRUE(tbl_a.get_arrow()->Equals(*tbl_b.get_arrow()));
 }

--- a/cpp/tests/test_parquet.cpp
+++ b/cpp/tests/test_parquet.cpp
@@ -42,7 +42,8 @@ TYPED_TEST(NumericParquetTest, ReadWrite)
   //     in order to wait until all files has been written to disk.
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
-  LogicalTable tbl_b = parquet_read(tmp_dir.path() / "*.parquet");
+  auto files         = parse_glob(tmp_dir.path() / "*.parquet");
+  LogicalTable tbl_b = parquet_read(files);
 
   EXPECT_TRUE(tbl_a.get_arrow()->Equals(*tbl_b.get_arrow()));
 }
@@ -64,7 +65,8 @@ TYPED_TEST(NumericParquetTest, ReadColumnSubset)
 
   std::vector<std::string> columns({"b"});
   tbl_a              = tbl_a.select(columns);
-  LogicalTable tbl_b = parquet_read(tmp_dir.path() / "*.parquet", columns);
+  auto files         = parse_glob(tmp_dir.path() / "*.parquet");
+  LogicalTable tbl_b = parquet_read(files, columns);
 
   EXPECT_TRUE(tbl_a.get_arrow()->Equals(*tbl_b.get_arrow()));
 }
@@ -83,7 +85,8 @@ TYPED_TEST(NumericParquetTest, ReadWriteSingleItem)
   //     in order to wait until all files has been written to disk.
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
-  LogicalTable tbl_b = parquet_read(tmp_dir.path() / "*.parquet");
+  auto files         = parse_glob(tmp_dir.path() / "*.parquet");
+  LogicalTable tbl_b = parquet_read(files);
   EXPECT_TRUE(tbl_a.get_arrow()->Equals(*tbl_b.get_arrow()));
 }
 
@@ -102,7 +105,8 @@ TEST(StringsParquetTest, ReadWrite)
   //     in order to wait until all files has been written to disk.
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
-  LogicalTable tbl_b = parquet_read(tmp_dir.path() / "*.parquet");
+  auto files         = parse_glob(tmp_dir.path() / "*.parquet");
+  LogicalTable tbl_b = parquet_read(files);
 
   EXPECT_TRUE(tbl_a.get_arrow()->Equals(*tbl_b.get_arrow()));
 }

--- a/python/examples/hello_world.py
+++ b/python/examples/hello_world.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 import tempfile
@@ -38,7 +38,7 @@ def main(tmpdir):
     # Then we can read the parquet files back into a logical table. We
     # provide a Glob string that reference all the parquet files that
     # should go into the logical table.
-    tbl2 = parquet_read(glob_string=f"{tmpdir}/*.parquet")
+    tbl2 = parquet_read(f"{tmpdir}/*.parquet")
 
     # LogicalColumn implements the `__legate_data_interface__` interface,
     # which makes it possible for other Legate libraries, such as cuPyNumeric,

--- a/python/legate_dataframe/ldf_polars/dsl/ir.py
+++ b/python/legate_dataframe/ldf_polars/dsl/ir.py
@@ -538,10 +538,7 @@ class Scan(IR):
             # polars skips blank lines at the beginning of the file
             if n_rows != -1:
                 raise NotImplementedError(f"{n_rows=}")
-            if len(paths) != 1:
-                raise NotImplementedError(f"multiple files: {paths=}")
 
-            path = paths[0]
             skiprows = reader_options.pop("skip_rows")
             if not POLARS_VERSION_LT_128:
                 skiprows += skip_rows  # pragma: no cover
@@ -579,7 +576,7 @@ class Scan(IR):
                 )
 
             table = csv.csv_read(
-                path,
+                paths,
                 delimiter=sep,
                 # header=header,  TODO: Should be fine to ignore?
                 usecols=column_names,
@@ -590,9 +587,6 @@ class Scan(IR):
             df = DataFrame.from_table(table)
         elif typ == "parquet":
             # TODO: We should support pushing some predicates into the parquet reader
-            path = paths[0]
-            if len(paths) != 1:
-                raise NotImplementedError(f"multiple files: {paths=}")
 
             if n_rows != -1:
                 raise NotImplementedError(
@@ -603,7 +597,7 @@ class Scan(IR):
                     f"{skip_rows=} only full read supported right now"
                 )
 
-            table = parquet.parquet_read(path, columns=with_columns)
+            table = parquet.parquet_read(paths, columns=with_columns)
             df = DataFrame.from_table(table)
         else:
             raise NotImplementedError(

--- a/python/legate_dataframe/lib/csv.pyi
+++ b/python/legate_dataframe/lib/csv.pyi
@@ -14,7 +14,7 @@ def csv_write(
     tbl: LogicalTable, path: pathlib.Path | str, delimiter: str = ","
 ) -> None: ...
 def csv_read(
-    glob_string: pathlib.Path | str,
+    files: pathlib.Path | str | Iterable[pathlib.Path | str],
     *,
     dtypes: Iterable[DTypeLike | plc.DataType | pa.DataType],
     na_filter: bool = False,

--- a/python/legate_dataframe/lib/parquet.pyi
+++ b/python/legate_dataframe/lib/parquet.pyi
@@ -13,10 +13,12 @@ from legate_dataframe.lib.core.table import LogicalTable
 
 def parquet_write(tbl: LogicalTable, path: pathlib.Path | str) -> None: ...
 def parquet_read(
-    glob_string: pathlib.Path | str, *, columns: Iterable[str] | None
+    files: pathlib.Path | str | Iterable[pathlib.Path | str],
+    *,
+    columns: Iterable[str] | None,
 ) -> LogicalTable: ...
 def parquet_read_array(
-    glob_string: pathlib.Path | str,
+    files: pathlib.Path | str | Iterable[pathlib.Path | str],
     *,
     columns: Iterable[str] | None = None,
     null_value: legate.core.Scalar | None = None,

--- a/python/tests/test_parquet.py
+++ b/python/tests/test_parquet.py
@@ -239,3 +239,16 @@ def test_read_polars(tmp_path, df, columns):
         q = q.select(columns)
 
     assert_matches_polars(q, allow_exceptions=pl.exceptions.ColumnNotFoundError)
+
+
+def test_multiple_files_polars(tmp_path, glob_string="/*"):
+    # Simple additional test that loads multiple files
+    pl = pytest.importorskip("polars")
+
+    df = pa.table({"a": np.arange(983, dtype="int64")})
+    npartitions = 100
+    write_partitioned_parquet(df, tmp_path, npartitions=npartitions)
+    assert len(glob.glob(str(tmp_path) + glob_string)) == npartitions
+
+    q = pl.scan_parquet(str(tmp_path) + glob_string)
+    assert_matches_polars(q)


### PR DESCRIPTION
This may make the C++ API somewhat inconvenient here, so I would be happy to introduce an overload for a single string that uses glob (potentially moving it back from Python to C++).
OTOH, I feel a bit that glob utility is maybe enough in C++ (and I am not sure we should care too much about convenience there)

While multiple files are usually globs, polars will helpfull expand them so that we need this version.

Breaks:
* C++ API for file loading.
* Python API if you pass the path as keyword arg (which seems niche)

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [x] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
