### PR TITLE
BUG: `LogicalTable.to_array()` should use the column `to_array()`

### DIFF
--- a/python/legate_dataframe/lib/core/table.pyx
+++ b/python/legate_dataframe/lib/core/table.pyx
@@ -317,7 +317,9 @@ cdef class LogicalTable:
         """
         from cupynumeric import stack
 
-        return stack([self[n] for n in range(self.num_columns())], axis=1, out=out)
+        return stack(
+            [self[n].to_array() for n in range(self.num_columns())], axis=1, out=out
+        )
 
     def to_cudf(self) -> cudf.DataFrame:
         """Copy the logical table into a local cudf table


### PR DESCRIPTION
We need to use the `to_array()` function to work around the nullability issue and add the convenience of allowing epxort when there are no nulls (by doing an actual count if needed).

The initial/old version was missing this.

---

Admittedly, the test isn't _quite_ spot-on, because I think the conversion from arrow will make the column non-nullable (seeing there are no nulls).  So only the second part really tests things (by checking for the custom error that comes from counting).