### PR TITLE
Add explicit NCCL depdencency

### DIFF
--- a/conda/environments/all_cuda-124_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-124_arch-x86_64.yaml
@@ -30,7 +30,6 @@ dependencies:
 - librmm==25.04.*,>=0.0.0a0
 - make
 - myst-parser>=4.0
-- nccl
 - nccl>=2.19
 - ninja
 - numpy >=1.23,<3.0.0a0

--- a/conda/environments/all_cuda-124_arch-x86_64.yaml
+++ b/conda/environments/all_cuda-124_arch-x86_64.yaml
@@ -30,6 +30,8 @@ dependencies:
 - librmm==25.04.*,>=0.0.0a0
 - make
 - myst-parser>=4.0
+- nccl
+- nccl>=2.19
 - ninja
 - numpy >=1.23,<3.0.0a0
 - openssh

--- a/conda/recipes/legate-dataframe/conda_build_config.yaml
+++ b/conda/recipes/legate-dataframe/conda_build_config.yaml
@@ -25,5 +25,8 @@ legate_version:
 cupynumeric_version:
   - "=25.08.*,>=0.0.0.dev0"
 
+nccl_version:
+  - ">=2.19"
+
 rapids_version:
   - =25.04.*

--- a/conda/recipes/legate-dataframe/meta.yaml
+++ b/conda/recipes/legate-dataframe/meta.yaml
@@ -103,7 +103,7 @@ outputs:
         - pynvjitlink<=0.6
     ignore_run_exports_from:
       - cupynumeric  # only a build dependency to help resolver
-      - nncl  # cargo-culted from raft (assume the pin is overly strict)
+      - nccl  # taken from raft (maybe due to being only a major version pin?)
     run_exports:
       - {{ pin_subpackage("legate-dataframe", max_pin="x.x") }}
     test:

--- a/conda/recipes/legate-dataframe/meta.yaml
+++ b/conda/recipes/legate-dataframe/meta.yaml
@@ -60,6 +60,7 @@ requirements:
     - cudf {{ rapids_version }}  # pulls in pyarrow?
     - libcudf {{ rapids_version }}
     - librmm {{ rapids_version }}
+    - nccl {{ nccl_version }}
     - pylibcudf {{ rapids_version }}
 
 
@@ -96,11 +97,13 @@ outputs:
         # released, a new legate-dataframe would be required.
         - legate
         - numpy >=1.23,<3.0.0a0
+        - nccl {{ nccl_version }}
         - rmm {{ rapids_version }}
         - cudf {{ rapids_version }}
         - pynvjitlink<=0.6
     ignore_run_exports_from:
       - cupynumeric  # only a build dependency to help resolver
+      - nncl  # cargo-culted from raft (assume the pin is overly strict)
     run_exports:
       - {{ pin_subpackage("legate-dataframe", max_pin="x.x") }}
     test:

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -85,9 +85,11 @@ rapids_find_generate_module(
   NCCL
   HEADER_NAMES nccl.h
   LIBRARY_NAMES nccl
-  BUILD_EXPORT_SET LegateDataframe-exports
-  INSTALL_EXPORT_SET LegateDataframe-exports
 )
+
+# Currently NCCL has no CMake build-system so we require it built and installed on the machine
+# already
+rapids_find_package(NCCL REQUIRED)
 
 rapids_find_package(
   legate REQUIRED Legion LegionRuntime

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -81,6 +81,14 @@ rapids_cpm_cccl()
 include(cmake/thirdparty/get_rmm.cmake)
 include(cmake/thirdparty/get_cudf.cmake)
 
+rapids_find_generate_module(
+  NCCL
+  HEADER_NAMES nccl.h
+  LIBRARY_NAMES nccl
+  BUILD_EXPORT_SET LegateDataframe-exports
+  INSTALL_EXPORT_SET LegateDataframe-exports
+)
+
 rapids_find_package(
   legate REQUIRED Legion LegionRuntime
   BUILD_EXPORT_SET LegateDataframe-exports
@@ -152,8 +160,9 @@ target_include_directories(
 )
 
 target_link_libraries(
-  LegateDataframe PUBLIC legate::legate rmm::rmm cudf::cudf Arrow::arrow_shared
-                         ArrowAcero::arrow_acero_shared Parquet::parquet_shared
+  LegateDataframe
+  PUBLIC legate::legate rmm::rmm cudf::cudf Arrow::arrow_shared
+  PRIVATE ArrowAcero::arrow_acero_shared Parquet::parquet_shared NCCL::NCCL
 )
 
 # Add Conda library, and include paths if specified

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -15,6 +15,7 @@ files:
       - depends_on_legate
       - depends_on_libcudf
       - depends_on_librmm
+      - depends_on_nccl
       - docs
       - py_version
       - run
@@ -47,6 +48,7 @@ files:
       - build
       - depends_on_legate
       - depends_on_libcudf
+      - depends_on_nccl
   py_run:
     output: pyproject
     pyproject_dir: python
@@ -55,6 +57,7 @@ files:
     includes:
       - depends_on_cudf
       - depends_on_legate
+      - depends_on_nccl
       - run
   py_test:
     output: pyproject
@@ -165,6 +168,9 @@ dependencies:
       - output_types: [conda, pyproject, requirements]
         packages:
           - numpy >=1.23,<3.0.0a0
+      - output_types: conda
+        packages:
+          - nccl
 
   test:
     common:
@@ -249,3 +255,19 @@ dependencies:
           - matrix:
             packages:
               - *librmm_unsuffixed
+
+  depends_on_nccl:
+    common:
+      - output_types: conda
+        packages:
+          - &nccl_unsuffixed nccl>=2.19
+    specific:
+      - output_types: [pyproject, requirements]
+        matrices:
+          - matrix:
+              cuda: "12.*"
+              cuda_suffixed: "true"
+            packages:
+              - nvidia-nccl-cu12>=2.19
+          - matrix:
+            packages:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -168,10 +168,6 @@ dependencies:
       - output_types: [conda, pyproject, requirements]
         packages:
           - numpy >=1.23,<3.0.0a0
-      - output_types: conda
-        packages:
-          - nccl
-
   test:
     common:
       - output_types: [conda, requirements, pyproject]
@@ -260,7 +256,7 @@ dependencies:
     common:
       - output_types: conda
         packages:
-          - &nccl_unsuffixed nccl>=2.19
+          - nccl>=2.19
     specific:
       - output_types: [pyproject, requirements]
         matrices:


### PR DESCRIPTION
This is largely cargo-culted from raft.  It seems that newer legate versions do not use nccl anymore and our transitive dependency will break.

Not clearly tested without the new legate, so we may want to wait until we actually see the change (which means until cupynumeric updates it's legate dependency).

---

Ping @reazulhoque since you ran into this with the newer legate.