### PR TITLE
Finish support for slice/head/tail in polars

### DIFF
--- a/python/legate_dataframe/ldf_polars/containers/column.py
+++ b/python/legate_dataframe/ldf_polars/containers/column.py
@@ -140,5 +140,11 @@ class Column:
         if zlice is None:
             return self.copy()
 
-        # TODO: This is a more important one, due to .head() and .tail()
-        raise NotImplementedError("slice not implemented")
+        start = zlice[0]
+        if zlice[1] is None:
+            stop = None
+        else:
+            stop = start + zlice[1]
+            if start < 0 and stop == 0:
+                stop = None
+        return type(self)(self.obj[slice(start, stop)], name=self.name)

--- a/python/legate_dataframe/ldf_polars/containers/dataframe.py
+++ b/python/legate_dataframe/ldf_polars/containers/dataframe.py
@@ -172,5 +172,11 @@ class DataFrame:
         if zlice is None:
             return self.copy()
 
-        # TODO: This is a more important one, due to .head() and .tail()
-        raise NotImplementedError("slice not implemented")
+        start = zlice[0]
+        if zlice[1] is None:
+            stop = None
+        else:
+            stop = start + zlice[1]
+            if start < 0 and stop == 0:
+                stop = None
+        return type(self).from_table(self.table.slice(slice(start, stop)))

--- a/python/legate_dataframe/ldf_polars/dsl/ir.py
+++ b/python/legate_dataframe/ldf_polars/dsl/ir.py
@@ -1170,7 +1170,7 @@ class Slice(IR):
     @classmethod
     def do_evaluate(cls, offset: int, length: int, df: DataFrame) -> DataFrame:
         """Evaluate and return a dataframe."""
-        raise NotImplementedError("slice is not implemented")
+        return df.slice((offset, length))
 
 
 class Filter(IR):


### PR DESCRIPTION
In most cases, these are actually pushed to a lower level and would be better tested on the individual function, but the test does catch at least one of the table paths.

In practice, e.g. sorting also should get the `limit=` so that the distributed sort can do less work (even if it still will do/need the final slice).
