### PR TITLE
Fix multi-gpu sort tests and tighten duplicate column check

### DIFF
--- a/cpp/src/sort.cpp
+++ b/cpp/src/sort.cpp
@@ -726,6 +726,8 @@ LogicalTable sort(const LogicalTable& tbl,
 
   bool use_arrow          = runtime->get_machine().count(legate::mapping::TaskTarget::GPU) == 0;
   const auto& name_to_idx = tbl.get_column_names();
+  auto keys_set           = std::unordered_set<std::string>(keys.begin(), keys.end());
+  if (keys_set.size() != keys.size()) { throw std::invalid_argument("duplicate sort keys"); }
   for (size_t i = 0; i < keys.size(); i++) {
     if (name_to_idx.count(keys[i]) == 0) {
       throw std::invalid_argument("sort key '" + keys[i] + "' not found in table");


### PR DESCRIPTION
All except the stable GPU sort code paths seems to just forgive the same column being repeated multiple times, but this one crashed pretty cryptically (and the old tests accidentally triggered that).

I have not thought about dropping the key (although you would have to also drop the second order if passed)