### PR TITLE
ENH: Inform legate that some joins don't need a concurrent task launch

### DIFF
--- a/cpp/include/legate_dataframe/core/library.hpp
+++ b/cpp/include/legate_dataframe/core/library.hpp
@@ -40,6 +40,7 @@ enum : int {
   BinaryOpColScalar,
   BinaryOpScalarCol,
   Join,
+  JoinConcurrent,
   ToTimestamps,
   ExtractTimestampComponent,
   ReduceLocal,

--- a/cpp/src/join.cpp
+++ b/cpp/src/join.cpp
@@ -202,11 +202,13 @@ bool is_repartition_not_needed(const TaskContext& ctx,
 
 }  // namespace
 
-class JoinTask : public Task<JoinTask, OpCode::Join> {
+template <bool needs_communication>
+class JoinTask : public Task<JoinTask<needs_communication>,
+                             needs_communication ? OpCode::JoinConcurrent : OpCode::Join> {
  public:
   static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
                                                 .with_has_allocations(true)
-                                                .with_concurrent(true)
+                                                .with_concurrent(needs_communication)
                                                 .with_elide_device_ctx_sync(true);
 
   static void gpu_variant(legate::TaskContext context)
@@ -346,12 +348,27 @@ LogicalTable join(const LogicalTable& lhs,
     }
   }
 
+  // Some calls broadcast inputs and thus do not need communication, in that case we
+  // can use the non-concurrent task variant and do not need to add a communicator.
+  bool needs_communication = false;
+  if (broadcast == BroadcastInput::AUTO) {
+    needs_communication = true;
+  } else if (join_type == JoinType::FULL ||
+             (broadcast == BroadcastInput::LEFT && join_type != JoinType::INNER)) {
+    throw std::runtime_error(
+      "Force broadcast was indicated, but repartitioning is required. "
+      "FULL joins do not support broadcasting and LEFT joins only for the "
+      "right hand side argument.");
+  }
+
   // Create the output table
   auto ret_names = concat(lhs_out.get_column_name_vector(), rhs_out.get_column_name_vector());
   auto ret       = LogicalTable(std::move(ret_cols), std::move(ret_names));
 
-  legate::AutoTask task =
-    runtime->create_task(get_library(), task::JoinTask::TASK_CONFIG.task_id());
+  auto task_id =
+    (needs_communication ? legate::dataframe::task::JoinTask<true>::TASK_CONFIG.task_id()
+                         : legate::dataframe::task::JoinTask<false>::TASK_CONFIG.task_id());
+  legate::AutoTask task = runtime->create_task(get_library(), task_id);
   // TODO: While legate may broadcast some arrays, it would be good to add
   //       a heuristic (e.g. based on the fact that we need to do copies
   //       anyway, so the broadcast may actually copy less).
@@ -375,15 +392,8 @@ LogicalTable join(const LogicalTable& lhs,
     }
   }
 
-  if (broadcast == BroadcastInput::AUTO) {
-    task.add_communicator("nccl");
-  } else if (join_type == JoinType::FULL ||
-             (broadcast == BroadcastInput::LEFT && join_type != JoinType::INNER)) {
-    throw std::runtime_error(
-      "Force broadcast was indicated, but repartitioning is required. "
-      "FULL joins do not support broadcasting and LEFT joins only for the "
-      "right hand side argument.");
-  }
+  if (needs_communication) { task.add_communicator("nccl"); }
+
   runtime->submit(std::move(task));
   return ret;
 }
@@ -458,7 +468,8 @@ namespace {
 
 void __attribute__((constructor)) register_tasks()
 {
-  legate::dataframe::task::JoinTask::register_variants();
+  legate::dataframe::task::JoinTask<true>::register_variants();
+  legate::dataframe::task::JoinTask<false>::register_variants();
 }
 
 }  // namespace


### PR DESCRIPTION
If we don't need a communicator because we have a broadcast join, we also don't need a concurrent task launch at all.

Includes gh-95 to make the templating slightly nicer.

---

Didn't try locally (machine I usually use is currently unavailable).