### PR TITLE
MAINT: Revert task registration restructure

### DIFF
--- a/cpp/include/legate_dataframe/core/library.hpp
+++ b/cpp/include/legate_dataframe/core/library.hpp
@@ -55,7 +55,8 @@ struct Registry {
 
 template <typename T, int ID>
 struct Task : public legate::LegateTask<T> {
-  using Registrar = Registry;
+  using Registrar                      = Registry;
+  static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{ID}};
 };
 
 }  // namespace task

--- a/cpp/src/binaryop.cpp
+++ b/cpp/src/binaryop.cpp
@@ -75,9 +75,6 @@ cudf::binary_operator arrow_to_cudf_binary_op(std::string op, legate::Type outpu
 
 class BinaryOpColColTask : public Task<BinaryOpColColTask, OpCode::BinaryOpColCol> {
  public:
-  static inline const auto TASK_CONFIG =
-    legate::TaskConfig{legate::LocalTaskID{OpCode::BinaryOpColCol}};
-
   static void cpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -172,10 +169,10 @@ class BinaryOpColColTask : public Task<BinaryOpColColTask, OpCode::BinaryOpColCo
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::BinaryOpColColTask::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace
 

--- a/cpp/src/csv.cpp
+++ b/cpp/src/csv.cpp
@@ -39,8 +39,6 @@ namespace legate::dataframe::task {
 
 class CSVWrite : public Task<CSVWrite, OpCode::CSVWrite> {
  public:
-  static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{OpCode::CSVWrite}};
-
   static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
                                                 .with_has_allocations(true)
                                                 .with_elide_device_ctx_sync(true)
@@ -89,8 +87,6 @@ class CSVWrite : public Task<CSVWrite, OpCode::CSVWrite> {
 
 class CSVRead : public Task<CSVRead, OpCode::CSVRead> {
  public:
-  static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{OpCode::CSVRead}};
-
   static void cpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -257,11 +253,11 @@ class CSVRead : public Task<CSVRead, OpCode::CSVRead> {
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::CSVWrite::register_variants();
   legate::dataframe::task::CSVRead::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace
 

--- a/cpp/src/filling.cpp
+++ b/cpp/src/filling.cpp
@@ -29,8 +29,6 @@ namespace task {
 
 class SequenceTask : public Task<SequenceTask, OpCode::Sequence> {
  public:
-  static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{OpCode::Sequence}};
-
   static void cpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -98,9 +96,9 @@ LogicalColumn sequence(size_t size, int64_t init)
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::SequenceTask::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace

--- a/cpp/src/groupby_aggregation.cpp
+++ b/cpp/src/groupby_aggregation.cpp
@@ -151,9 +151,6 @@ cudf::aggregation::Kind arrow_to_cudf_aggregation(const std::string& agg_name)
 
 class GroupByAggregationTask : public Task<GroupByAggregationTask, OpCode::GroupByAggregation> {
  public:
-  static inline const auto TASK_CONFIG =
-    legate::TaskConfig{legate::LocalTaskID{OpCode::GroupByAggregation}};
-
   static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
                                                 .with_has_allocations(true)
                                                 .with_concurrent(true)
@@ -377,9 +374,9 @@ LogicalTable groupby_aggregation(
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::GroupByAggregationTask::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace

--- a/cpp/src/join.cpp
+++ b/cpp/src/join.cpp
@@ -204,8 +204,6 @@ bool is_repartition_not_needed(const TaskContext& ctx,
 
 class JoinTask : public Task<JoinTask, OpCode::Join> {
  public:
-  static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{OpCode::Join}};
-
   static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
                                                 .with_has_allocations(true)
                                                 .with_concurrent(true)
@@ -458,9 +456,9 @@ LogicalTable join(const LogicalTable& lhs,
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::JoinTask::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace

--- a/cpp/src/parquet.cpp
+++ b/cpp/src/parquet.cpp
@@ -46,9 +46,6 @@ namespace legate::dataframe::task {
 
 class ParquetWrite : public Task<ParquetWrite, OpCode::ParquetWrite> {
  public:
-  static inline const auto TASK_CONFIG =
-    legate::TaskConfig{legate::LocalTaskID{OpCode::ParquetWrite}};
-
   static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
                                                 .with_has_allocations(true)
                                                 .with_elide_device_ctx_sync(true)
@@ -153,9 +150,6 @@ struct create_result_store_fn {
 
 class ParquetRead : public Task<ParquetRead, OpCode::ParquetRead> {
  public:
-  static inline const auto TASK_CONFIG =
-    legate::TaskConfig{legate::LocalTaskID{OpCode::ParquetRead}};
-
   static void cpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -268,9 +262,6 @@ class ParquetRead : public Task<ParquetRead, OpCode::ParquetRead> {
 
 class ParquetReadArray : public Task<ParquetReadArray, OpCode::ParquetReadArray> {
  public:
-  static inline const auto TASK_CONFIG =
-    legate::TaskConfig{legate::LocalTaskID{OpCode::ParquetReadArray}};
-
   static void cpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -423,12 +414,12 @@ namespace legate::dataframe {
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::ParquetWrite::register_variants();
   legate::dataframe::task::ParquetRead::register_variants();
   legate::dataframe::task::ParquetReadArray::register_variants();
-  return 0;
-}();
+}
 
 struct ParquetReadInfo {
   std::vector<std::string> column_names;

--- a/cpp/src/reduction.cpp
+++ b/cpp/src/reduction.cpp
@@ -64,9 +64,6 @@ std::unique_ptr<cudf::reduce_aggregation> make_cudf_reduce_aggregation(const std
 
 class ReduceLocalTask : public Task<ReduceLocalTask, OpCode::ReduceLocal> {
  public:
-  static inline const auto TASK_CONFIG =
-    legate::TaskConfig{legate::LocalTaskID{OpCode::ReduceLocal}};
-
   static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}.with_has_allocations(true);
 
   static void cpu_variant(legate::TaskContext context)
@@ -460,9 +457,9 @@ LogicalColumn reduce(const LogicalColumn& col,
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::ReduceLocalTask::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace

--- a/cpp/src/replace.cpp
+++ b/cpp/src/replace.cpp
@@ -33,9 +33,6 @@ namespace task {
 
 class ReplaceNullScalarTask : public Task<ReplaceNullScalarTask, OpCode::ReplaceNullsWithScalar> {
  public:
-  static inline const auto TASK_CONFIG =
-    legate::TaskConfig{legate::LocalTaskID{OpCode::ReplaceNullsWithScalar}};
-
   static void cpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -111,9 +108,9 @@ LogicalColumn replace_nulls(const LogicalColumn& col, const LogicalColumn& scala
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::ReplaceNullScalarTask::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace

--- a/cpp/src/sort.cpp
+++ b/cpp/src/sort.cpp
@@ -574,8 +574,6 @@ static std::unique_ptr<cudf::table> apply_limit(std::unique_ptr<cudf::table> tbl
 
 class SortTask : public Task<SortTask, OpCode::Sort> {
  public:
-  static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{OpCode::Sort}};
-
   static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
                                                 .with_has_allocations(true)
                                                 .with_concurrent(true)
@@ -802,9 +800,9 @@ LogicalTable sort(const LogicalTable& tbl,
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::SortTask::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace

--- a/cpp/src/stream_compaction.cpp
+++ b/cpp/src/stream_compaction.cpp
@@ -32,9 +32,6 @@ namespace task {
 
 class ApplyBooleanMaskTask : public Task<ApplyBooleanMaskTask, OpCode::ApplyBooleanMask> {
  public:
-  static inline const auto TASK_CONFIG =
-    legate::TaskConfig{legate::LocalTaskID{OpCode::ApplyBooleanMask}};
-
   static void cpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -96,9 +93,9 @@ LogicalTable apply_boolean_mask(const LogicalTable& tbl, const LogicalColumn& bo
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::ApplyBooleanMaskTask::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace

--- a/cpp/src/timestamps.cpp
+++ b/cpp/src/timestamps.cpp
@@ -30,9 +30,6 @@ namespace task {
 
 class ToTimestampsTask : public Task<ToTimestampsTask, OpCode::ToTimestamps> {
  public:
-  static inline const auto TASK_CONFIG =
-    legate::TaskConfig{legate::LocalTaskID{OpCode::ToTimestamps}};
-
   static void gpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -54,9 +51,6 @@ class ToTimestampsTask : public Task<ToTimestampsTask, OpCode::ToTimestamps> {
 class ExtractTimestampComponentTask
   : public Task<ExtractTimestampComponentTask, OpCode::ExtractTimestampComponent> {
  public:
-  static inline const auto TASK_CONFIG =
-    legate::TaskConfig{legate::LocalTaskID{OpCode::ExtractTimestampComponent}};
-
   static void gpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -123,10 +117,10 @@ LogicalColumn extract_timestamp_component(const LogicalColumn& input,
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::ToTimestampsTask::register_variants();
   legate::dataframe::task::ExtractTimestampComponentTask::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace

--- a/cpp/src/unaryop.cpp
+++ b/cpp/src/unaryop.cpp
@@ -32,8 +32,6 @@ namespace task {
 
 class CastTask : public Task<CastTask, OpCode::Cast> {
  public:
-  static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{OpCode::Cast}};
-
   static void cpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -91,8 +89,6 @@ cudf::unary_operator arrow_to_cudf_unary_op(std::string op)
 
 class UnaryOpTask : public Task<UnaryOpTask, OpCode::UnaryOp> {
  public:
-  static inline const auto TASK_CONFIG = legate::TaskConfig{legate::LocalTaskID{OpCode::UnaryOp}};
-
   static void cpu_variant(legate::TaskContext context)
   {
     TaskContext ctx{context};
@@ -172,10 +168,10 @@ LogicalColumn unary_operation(const LogicalColumn& col, std::string op)
 
 namespace {
 
-const auto reg_id_ = []() -> char {
+void __attribute__((constructor)) register_tasks()
+{
   legate::dataframe::task::CastTask::register_variants();
   legate::dataframe::task::UnaryOpTask::register_variants();
-  return 0;
-}();
+}
 
 }  // namespace


### PR DESCRIPTION
Intermittently, legate didn't support this pattern, so we had to add the TASK_CONFIG init to every task and change the registration pattern to happen late (rather than at any time).

This was only necessary temporarily, but I had not reverted it before.
