### PR TITLE
Refactor cuda code into .cu files

### DIFF
--- a/cpp/include/legate_dataframe/binaryop.hpp
+++ b/cpp/include/legate_dataframe/binaryop.hpp
@@ -83,6 +83,6 @@ class BinaryOpColColTask : public Task<BinaryOpColColTask, OpCode::BinaryOpColCo
 LogicalColumn binary_operation(const LogicalColumn& lhs,
                                const LogicalColumn& rhs,
                                std::string op,
-                               cudf::data_type output_type);
+                               std::shared_ptr<arrow::DataType> output_type);
 
 }  // namespace legate::dataframe

--- a/cpp/include/legate_dataframe/binaryop.hpp
+++ b/cpp/include/legate_dataframe/binaryop.hpp
@@ -19,11 +19,6 @@
 #include <legate.h>
 #include <legate_dataframe/core/column.hpp>
 #include <legate_dataframe/core/library.hpp>
-#include <legate_dataframe/core/table.hpp>
-#include <legate_dataframe/core/task_argument.hpp>
-#include <legate_dataframe/core/task_context.hpp>
-
-#include <legate_dataframe/core/column.hpp>
 
 namespace legate::dataframe {
 

--- a/cpp/include/legate_dataframe/binaryop.hpp
+++ b/cpp/include/legate_dataframe/binaryop.hpp
@@ -17,13 +17,48 @@
 #pragma once
 
 #include <legate.h>
-
-#include <cudf/binaryop.hpp>
+#include <legate_dataframe/core/column.hpp>
+#include <legate_dataframe/core/library.hpp>
+#include <legate_dataframe/core/table.hpp>
+#include <legate_dataframe/core/task_argument.hpp>
+#include <legate_dataframe/core/task_context.hpp>
 
 #include <legate_dataframe/core/column.hpp>
 
 namespace legate::dataframe {
 
+namespace task {
+const std::set<std::string> cudf_supported_binary_ops = {"add",
+                                                         "divide",
+                                                         "multiply",
+                                                         "power",
+                                                         "subtract",
+                                                         "bit_wise_and",
+                                                         "bit_wise_or",
+                                                         "bit_wise_xor",
+                                                         "shift_left",
+                                                         "shift_right",
+                                                         "logb",
+                                                         "atan2",
+                                                         "equal",
+                                                         "greater",
+                                                         "greater_equal",
+                                                         "less",
+                                                         "less_equal",
+                                                         "not_equal",
+                                                         // logical operators:
+                                                         "and",
+                                                         "or",
+                                                         "and_kleene",
+                                                         "or_kleene"};
+
+class BinaryOpColColTask : public Task<BinaryOpColColTask, OpCode::BinaryOpColCol> {
+ public:
+  static void cpu_variant(legate::TaskContext context);
+  static void gpu_variant(legate::TaskContext context);
+};
+
+}  // namespace task
 /**
  * @brief Performs a binary operation between two columns.
  *
@@ -43,11 +78,7 @@ namespace legate::dataframe {
  * @param output_type The desired data type of the output column
  * @return            Output column of `output_type` type containing the result of
  *                    the binary operation
- * @throw cudf::logic_error if @p lhs and @p rhs are different sizes
- * @throw cudf::logic_error if @p output_type dtype isn't boolean for comparison and logical
- * operations.
- * @throw cudf::logic_error if @p output_type dtype isn't fixed-width
- * @throw cudf::data_type_error if the operation is not supported for the types of @p lhs and @p rhs
+ * @throw std::invalid_argument if operator not supported
  */
 LogicalColumn binary_operation(const LogicalColumn& lhs,
                                const LogicalColumn& rhs,

--- a/cpp/include/legate_dataframe/csv.hpp
+++ b/cpp/include/legate_dataframe/csv.hpp
@@ -19,12 +19,30 @@
 #include <string>
 
 #include <cudf/types.hpp>
-
-#include <legate_dataframe/core/column.hpp>
+#include <legate.h>
+#include <legate_dataframe/core/library.hpp>
 #include <legate_dataframe/core/table.hpp>
 
 namespace legate::dataframe {
 
+namespace task {
+
+class CSVRead : public Task<CSVRead, OpCode::CSVRead> {
+ public:
+  static void cpu_variant(legate::TaskContext context);
+  static void gpu_variant(legate::TaskContext context);
+};
+
+class CSVWrite : public Task<CSVWrite, OpCode::CSVWrite> {
+ public:
+  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
+                                                .with_has_allocations(true)
+                                                .with_elide_device_ctx_sync(true)
+                                                .with_has_side_effect(true);
+  static void cpu_variant(legate::TaskContext context);
+  static void gpu_variant(legate::TaskContext context);
+};
+}  // namespace task
 /**
  * @brief Write table to csv files.
  *

--- a/cpp/include/legate_dataframe/csv.hpp
+++ b/cpp/include/legate_dataframe/csv.hpp
@@ -18,7 +18,6 @@
 
 #include <string>
 
-#include <cudf/types.hpp>
 #include <legate.h>
 #include <legate_dataframe/core/library.hpp>
 #include <legate_dataframe/core/table.hpp>
@@ -87,7 +86,7 @@ void csv_write(LogicalTable& tbl, const std::string& dirpath, char delimiter = '
  * @return The read LogicalTable.
  */
 LogicalTable csv_read(const std::vector<std::string>& files,
-                      const std::vector<cudf::data_type>& dtypes,
+                      const std::vector<std::shared_ptr<arrow::DataType>>& dtypes,
                       bool na_filter                                       = true,
                       char delimiter                                       = ',',
                       const std::optional<std::vector<std::string>>& names = std::nullopt,

--- a/cpp/src/binaryop.cpp
+++ b/cpp/src/binaryop.cpp
@@ -104,7 +104,7 @@ LogicalColumn binary_operation(const LogicalColumn& lhs,
   // This allows us to to throw nicely
   if (runtime->get_machine().count(legate::mapping::TaskTarget::GPU) > 0) {
     if (task::cudf_supported_binary_ops.count(op) == 0) {
-      throw std::invalid_argument("Unsupported binary operation: " + op);
+      throw std::invalid_argument("Unsupported binary operator: " + op);
     }
   } else {
     auto result = arrow::compute::GetFunctionRegistry()->GetFunction(op);

--- a/cpp/src/binaryop.cpp
+++ b/cpp/src/binaryop.cpp
@@ -14,12 +14,6 @@
  * limitations under the License.
  */
 
-#include <legate.h>
-
-#include <cudf/binaryop.hpp>
-#include <cudf/types.hpp>
-#include <cudf/unary.hpp>
-
 #include <arrow/compute/api.h>
 #include <legate_dataframe/binaryop.hpp>
 #include <legate_dataframe/core/column.hpp>
@@ -30,140 +24,61 @@
 
 namespace legate::dataframe::task {
 
-cudf::binary_operator arrow_to_cudf_binary_op(std::string op, legate::Type output_type)
+/*static*/ void BinaryOpColColTask::cpu_variant(legate::TaskContext context)
 {
-  // Arrow binary operators taken from the below list,
-  // where an equivalent cudf binary operator exists.
-  // https://arrow.apache.org/docs/cpp/compute.html#element-wise-scalar-functions
-  // https://docs.rapids.ai/api/libcudf/stable/group__transformation__binaryops
-  std::unordered_map<std::string, cudf::binary_operator> arrow_to_cudf_ops = {
-    {"add", cudf::binary_operator::ADD},
-    {"divide", cudf::binary_operator::DIV},
-    {"multiply", cudf::binary_operator::MUL},
-    {"power", cudf::binary_operator::POW},
-    {"subtract", cudf::binary_operator::SUB},
-    {"bit_wise_and", cudf::binary_operator::BITWISE_AND},
-    {"bit_wise_or", cudf::binary_operator::BITWISE_OR},
-    {"bit_wise_xor", cudf::binary_operator::BITWISE_XOR},
-    {"shift_left", cudf::binary_operator::SHIFT_LEFT},
-    {"shift_right", cudf::binary_operator::SHIFT_RIGHT},
-    {"logb", cudf::binary_operator::LOG_BASE},
-    {"atan2", cudf::binary_operator::ATAN2},
-    {"equal", cudf::binary_operator::EQUAL},
-    {"greater", cudf::binary_operator::GREATER},
-    {"greater_equal", cudf::binary_operator::GREATER_EQUAL},
-    {"less", cudf::binary_operator::LESS},
-    {"less_equal", cudf::binary_operator::LESS_EQUAL},
-    {"not_equal", cudf::binary_operator::NOT_EQUAL},
-    // logical operators:
-    {"and", cudf::binary_operator::LOGICAL_AND},
-    {"or", cudf::binary_operator::LOGICAL_OR},
-    {"and_kleene", cudf::binary_operator::NULL_LOGICAL_AND},
-    {"or_kleene", cudf::binary_operator::NULL_LOGICAL_OR},
-  };
+  TaskContext ctx{context};
+  auto op        = argument::get_next_scalar<std::string>(ctx);
+  const auto lhs = argument::get_next_input<PhysicalColumn>(ctx);
+  const auto rhs = argument::get_next_input<PhysicalColumn>(ctx);
+  auto output    = argument::get_next_output<PhysicalColumn>(ctx);
 
-  // Cudf has a special case for powers with integers
-  // https://github.com/rapidsai/cudf/issues/10178#issuecomment-3004143727
-  if (op == "power" && output_type.to_string().find("int") != std::string::npos) {
-    return cudf::binary_operator::INT_POW;
+  std::vector<arrow::Datum> args(2);
+  if (lhs.num_rows() == 1) {
+    auto scalar = ARROW_RESULT(lhs.arrow_array_view()->GetScalar(0));
+    args[0]     = scalar;
+  } else {
+    args[0] = lhs.arrow_array_view();
+  }
+  if (rhs.num_rows() == 1) {
+    auto scalar = ARROW_RESULT(rhs.arrow_array_view()->GetScalar(0));
+    args[1]     = scalar;
+  } else {
+    args[1] = rhs.arrow_array_view();
   }
 
-  if (arrow_to_cudf_ops.find(op) != arrow_to_cudf_ops.end()) { return arrow_to_cudf_ops[op]; }
-  throw std::invalid_argument("Could not find cudf binary operator matching: " + op);
-  return cudf::binary_operator::INVALID_BINARY;
-}
-
-class BinaryOpColColTask : public Task<BinaryOpColColTask, OpCode::BinaryOpColCol> {
- public:
-  static void cpu_variant(legate::TaskContext context)
-  {
-    TaskContext ctx{context};
-    auto op        = argument::get_next_scalar<std::string>(ctx);
-    const auto lhs = argument::get_next_input<PhysicalColumn>(ctx);
-    const auto rhs = argument::get_next_input<PhysicalColumn>(ctx);
-    auto output    = argument::get_next_output<PhysicalColumn>(ctx);
-
-    std::vector<arrow::Datum> args(2);
-    if (lhs.num_rows() == 1) {
-      auto scalar = ARROW_RESULT(lhs.arrow_array_view()->GetScalar(0));
-      args[0]     = scalar;
-    } else {
-      args[0] = lhs.arrow_array_view();
-    }
-    if (rhs.num_rows() == 1) {
-      auto scalar = ARROW_RESULT(rhs.arrow_array_view()->GetScalar(0));
-      args[1]     = scalar;
-    } else {
-      args[1] = rhs.arrow_array_view();
-    }
-
-    if (output.cudf_type().id() == cudf::type_id::BOOL8 &&
-        (op == "and" || op == "or" || op == "and_kleene" || op == "or_kleene")) {
-      // arrow doesn't seem to cast for the user for logical ops.
-      args[0] = ARROW_RESULT(arrow::compute::Cast(args[0], arrow::boolean()));
-      args[1] = ARROW_RESULT(arrow::compute::Cast(args[1], arrow::boolean()));
-    }
-
-    // Result may be scalar or array
-    auto datum_result = ARROW_RESULT(arrow::compute::CallFunction(op, args));
-
-    // Coerce the output type if necessary
-    auto arrow_result_type = to_arrow_type(output.cudf_type().id());
-    if (datum_result.type() != arrow_result_type) {
-      auto coerced_result = ARROW_RESULT(arrow::compute::Cast(
-        datum_result, arrow_result_type, arrow::compute::CastOptions::Unsafe()));
-      datum_result        = std::move(coerced_result);
-    }
-
-    if (datum_result.is_scalar()) {
-      auto as_array = ARROW_RESULT(arrow::MakeArrayFromScalar(*datum_result.scalar(), 1));
-      if (get_prefer_eager_allocations()) {
-        output.copy_into(std::move(as_array));
-      } else {
-        output.move_into(std::move(as_array));
-      }
-    } else {
-      if (get_prefer_eager_allocations()) {
-        output.copy_into(std::move(datum_result.make_array()));
-      } else {
-        output.move_into(std::move(datum_result.make_array()));
-      }
-    }
+  if (output.cudf_type().id() == cudf::type_id::BOOL8 &&
+      (op == "and" || op == "or" || op == "and_kleene" || op == "or_kleene")) {
+    // arrow doesn't seem to cast for the user for logical ops.
+    args[0] = ARROW_RESULT(arrow::compute::Cast(args[0], arrow::boolean()));
+    args[1] = ARROW_RESULT(arrow::compute::Cast(args[1], arrow::boolean()));
   }
 
-  static void gpu_variant(legate::TaskContext context)
-  {
-    TaskContext ctx{context};
-    auto arrow_op  = argument::get_next_scalar<std::string>(ctx);
-    const auto lhs = argument::get_next_input<PhysicalColumn>(ctx);
-    const auto rhs = argument::get_next_input<PhysicalColumn>(ctx);
-    auto output    = argument::get_next_output<PhysicalColumn>(ctx);
-    auto op        = arrow_to_cudf_binary_op(arrow_op, output.type());
+  // Result may be scalar or array
+  auto datum_result = ARROW_RESULT(arrow::compute::CallFunction(op, args));
 
-    std::unique_ptr<cudf::column> ret;
-    /*
-     * If one (not both) are length 1, use scalars as cudf doesn't allow
-     * broadcast binary operations.
-     */
-    if (lhs.num_rows() == 1 && rhs.num_rows() != 1) {
-      auto lhs_scalar = lhs.cudf_scalar();
-      ret             = cudf::binary_operation(
-        *lhs_scalar, rhs.column_view(), op, output.cudf_type(), ctx.stream(), ctx.mr());
-    } else if (rhs.num_rows() == 1 && lhs.num_rows() != 1) {
-      auto rhs_scalar = rhs.cudf_scalar();
-      ret             = cudf::binary_operation(
-        lhs.column_view(), *rhs_scalar, op, output.cudf_type(), ctx.stream(), ctx.mr());
-    } else {
-      ret = cudf::binary_operation(
-        lhs.column_view(), rhs.column_view(), op, output.cudf_type(), ctx.stream(), ctx.mr());
-    }
+  // Coerce the output type if necessary
+  auto arrow_result_type = to_arrow_type(output.cudf_type().id());
+  if (datum_result.type() != arrow_result_type) {
+    auto coerced_result = ARROW_RESULT(
+      arrow::compute::Cast(datum_result, arrow_result_type, arrow::compute::CastOptions::Unsafe()));
+    datum_result = std::move(coerced_result);
+  }
+
+  if (datum_result.is_scalar()) {
+    auto as_array = ARROW_RESULT(arrow::MakeArrayFromScalar(*datum_result.scalar(), 1));
     if (get_prefer_eager_allocations()) {
-      output.copy_into(std::move(ret));
+      output.copy_into(std::move(as_array));
     } else {
-      output.move_into(std::move(ret));
+      output.move_into(std::move(as_array));
+    }
+  } else {
+    if (get_prefer_eager_allocations()) {
+      output.copy_into(std::move(datum_result.make_array()));
+    } else {
+      output.move_into(std::move(datum_result.make_array()));
     }
   }
-};
+}
 
 }  // namespace legate::dataframe::task
 
@@ -188,8 +103,9 @@ LogicalColumn binary_operation(const LogicalColumn& lhs,
   // Check if the op is valid before we enter the task
   // This allows us to to throw nicely
   if (runtime->get_machine().count(legate::mapping::TaskTarget::GPU) > 0) {
-    // Throws if op doesn't exist
-    task::arrow_to_cudf_binary_op(op, to_legate_type(output_type.id()));
+    if (task::cudf_supported_binary_ops.count(op) == 0) {
+      throw std::invalid_argument("Unsupported binary operation: " + op);
+    }
   } else {
     auto result = arrow::compute::GetFunctionRegistry()->GetFunction(op);
     if (!result.ok()) {

--- a/cpp/src/binaryop.cpp
+++ b/cpp/src/binaryop.cpp
@@ -96,7 +96,7 @@ namespace legate::dataframe {
 LogicalColumn binary_operation(const LogicalColumn& lhs,
                                const LogicalColumn& rhs,
                                std::string op,
-                               cudf::data_type output_type)
+                               std::shared_ptr<arrow::DataType> output_type)
 {
   auto runtime = legate::Runtime::get_runtime();
 
@@ -117,7 +117,7 @@ LogicalColumn binary_operation(const LogicalColumn& lhs,
   auto scalar_result = lhs.is_scalar() && rhs.is_scalar();
   std::optional<size_t> size{};
   if (get_prefer_eager_allocations()) { size = lhs.is_scalar() ? rhs.num_rows() : lhs.num_rows(); }
-  auto ret = LogicalColumn::empty_like(std::move(output_type), nullable, scalar_result, size);
+  auto ret = LogicalColumn::empty_like(output_type, nullable, scalar_result, size);
   legate::AutoTask task =
     runtime->create_task(get_library(), task::BinaryOpColColTask::TASK_CONFIG.task_id());
   argument::add_next_scalar(task, op);

--- a/cpp/src/binaryop.cu
+++ b/cpp/src/binaryop.cu
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <legate.h>
+
+#include <cudf/binaryop.hpp>
+#include <cudf/types.hpp>
+#include <cudf/unary.hpp>
+
+#include <legate_dataframe/binaryop.hpp>
+#include <legate_dataframe/core/column.hpp>
+#include <legate_dataframe/core/library.hpp>
+#include <legate_dataframe/core/table.hpp>
+#include <legate_dataframe/core/task_argument.hpp>
+#include <legate_dataframe/core/task_context.hpp>
+
+namespace legate::dataframe::task {
+
+cudf::binary_operator arrow_to_cudf_binary_op(std::string op, legate::Type output_type)
+{
+  // Arrow binary operators taken from the below list,
+  // where an equivalent cudf binary operator exists.
+  // https://arrow.apache.org/docs/cpp/compute.html#element-wise-scalar-functions
+  // https://docs.rapids.ai/api/libcudf/stable/group__transformation__binaryops
+  std::unordered_map<std::string, cudf::binary_operator> arrow_to_cudf_ops = {
+    {"add", cudf::binary_operator::ADD},
+    {"divide", cudf::binary_operator::DIV},
+    {"multiply", cudf::binary_operator::MUL},
+    {"power", cudf::binary_operator::POW},
+    {"subtract", cudf::binary_operator::SUB},
+    {"bit_wise_and", cudf::binary_operator::BITWISE_AND},
+    {"bit_wise_or", cudf::binary_operator::BITWISE_OR},
+    {"bit_wise_xor", cudf::binary_operator::BITWISE_XOR},
+    {"shift_left", cudf::binary_operator::SHIFT_LEFT},
+    {"shift_right", cudf::binary_operator::SHIFT_RIGHT},
+    {"logb", cudf::binary_operator::LOG_BASE},
+    {"atan2", cudf::binary_operator::ATAN2},
+    {"equal", cudf::binary_operator::EQUAL},
+    {"greater", cudf::binary_operator::GREATER},
+    {"greater_equal", cudf::binary_operator::GREATER_EQUAL},
+    {"less", cudf::binary_operator::LESS},
+    {"less_equal", cudf::binary_operator::LESS_EQUAL},
+    {"not_equal", cudf::binary_operator::NOT_EQUAL},
+    // logical operators:
+    {"and", cudf::binary_operator::LOGICAL_AND},
+    {"or", cudf::binary_operator::LOGICAL_OR},
+    {"and_kleene", cudf::binary_operator::NULL_LOGICAL_AND},
+    {"or_kleene", cudf::binary_operator::NULL_LOGICAL_OR},
+  };
+
+  // Cudf has a special case for powers with integers
+  // https://github.com/rapidsai/cudf/issues/10178#issuecomment-3004143727
+  if (op == "power" && output_type.to_string().find("int") != std::string::npos) {
+    return cudf::binary_operator::INT_POW;
+  }
+
+  if (arrow_to_cudf_ops.find(op) != arrow_to_cudf_ops.end()) { return arrow_to_cudf_ops[op]; }
+  throw std::invalid_argument("Could not find cudf binary operator matching: " + op);
+  return cudf::binary_operator::INVALID_BINARY;
+}
+
+/*static*/ void BinaryOpColColTask::gpu_variant(legate::TaskContext context)
+{
+  TaskContext ctx{context};
+  auto arrow_op  = argument::get_next_scalar<std::string>(ctx);
+  const auto lhs = argument::get_next_input<PhysicalColumn>(ctx);
+  const auto rhs = argument::get_next_input<PhysicalColumn>(ctx);
+  auto output    = argument::get_next_output<PhysicalColumn>(ctx);
+  auto op        = arrow_to_cudf_binary_op(arrow_op, output.type());
+
+  std::unique_ptr<cudf::column> ret;
+  /*
+   * If one (not both) are length 1, use scalars as cudf doesn't allow
+   * broadcast binary operations.
+   */
+  if (lhs.num_rows() == 1 && rhs.num_rows() != 1) {
+    auto lhs_scalar = lhs.cudf_scalar();
+    ret             = cudf::binary_operation(
+      *lhs_scalar, rhs.column_view(), op, output.cudf_type(), ctx.stream(), ctx.mr());
+  } else if (rhs.num_rows() == 1 && lhs.num_rows() != 1) {
+    auto rhs_scalar = rhs.cudf_scalar();
+    ret             = cudf::binary_operation(
+      lhs.column_view(), *rhs_scalar, op, output.cudf_type(), ctx.stream(), ctx.mr());
+  } else {
+    ret = cudf::binary_operation(
+      lhs.column_view(), rhs.column_view(), op, output.cudf_type(), ctx.stream(), ctx.mr());
+  }
+  if (get_prefer_eager_allocations()) {
+    output.copy_into(std::move(ret));
+  } else {
+    output.move_into(std::move(ret));
+  }
+}
+
+}  // namespace legate::dataframe::task

--- a/cpp/src/csv.cpp
+++ b/cpp/src/csv.cpp
@@ -19,10 +19,7 @@
 #include <stdexcept>
 #include <vector>
 
-#include <cudf/concatenate.hpp>
-#include <cudf/io/csv.hpp>
 #include <legate.h>
-#include <rmm/device_buffer.hpp>
 
 #include <legate_dataframe/core/column.hpp>
 #include <legate_dataframe/core/library.hpp>
@@ -37,217 +34,101 @@
 
 namespace legate::dataframe::task {
 
-class CSVWrite : public Task<CSVWrite, OpCode::CSVWrite> {
- public:
-  static constexpr auto GPU_VARIANT_OPTIONS = legate::VariantOptions{}
-                                                .with_has_allocations(true)
-                                                .with_elide_device_ctx_sync(true)
-                                                .with_has_side_effect(true);
+/*static*/ void CSVWrite::cpu_variant(legate::TaskContext context)
+{
+  TaskContext ctx{context};
+  const std::string dirpath  = argument::get_next_scalar<std::string>(ctx);
+  const auto column_names    = argument::get_next_scalar_vector<std::string>(ctx);
+  const auto tbl             = argument::get_next_input<PhysicalTable>(ctx);
+  const std::string filepath = dirpath + "/part." + std::to_string(ctx.rank) + ".csv";
+  const auto delimiter       = static_cast<char>(argument::get_next_scalar<int32_t>(ctx));
 
-  static void cpu_variant(legate::TaskContext context)
-  {
-    TaskContext ctx{context};
-    const std::string dirpath  = argument::get_next_scalar<std::string>(ctx);
-    const auto column_names    = argument::get_next_scalar_vector<std::string>(ctx);
-    const auto tbl             = argument::get_next_input<PhysicalTable>(ctx);
-    const std::string filepath = dirpath + "/part." + std::to_string(ctx.rank) + ".csv";
-    const auto delimiter       = static_cast<char>(argument::get_next_scalar<int32_t>(ctx));
+  auto arrow_table        = tbl.arrow_table_view(column_names);
+  auto outfile            = arrow::io::FileOutputStream::Open(filepath).ValueOrDie();
+  auto write_options      = arrow::csv::WriteOptions::Defaults();
+  write_options.delimiter = delimiter;
 
-    auto arrow_table        = tbl.arrow_table_view(column_names);
-    auto outfile            = arrow::io::FileOutputStream::Open(filepath).ValueOrDie();
-    auto write_options      = arrow::csv::WriteOptions::Defaults();
-    write_options.delimiter = delimiter;
+  auto csv_writer =
+    arrow::csv::MakeCSVWriter(outfile, arrow_table->schema(), write_options).ValueOrDie();
+  auto status = csv_writer->WriteTable(*arrow_table);
+  status      = csv_writer->Close();
+  if (!status.ok()) { throw std::runtime_error("Failed to write CSV file: " + status.ToString()); }
+}
 
-    auto csv_writer =
-      arrow::csv::MakeCSVWriter(outfile, arrow_table->schema(), write_options).ValueOrDie();
-    auto status = csv_writer->WriteTable(*arrow_table);
-    status      = csv_writer->Close();
-    if (!status.ok()) {
-      throw std::runtime_error("Failed to write CSV file: " + status.ToString());
-    }
+/*static*/ void CSVRead::cpu_variant(legate::TaskContext context)
+{
+  TaskContext ctx{context};
+  const auto launch_domain    = context.get_launch_domain();
+  const auto file_paths       = argument::get_next_scalar_vector<std::string>(ctx);
+  const auto all_column_names = argument::get_next_scalar_vector<std::string>(ctx);
+  const auto use_cols_indexes = argument::get_next_scalar_vector<int>(ctx);
+  const auto na_filter        = argument::get_next_scalar<bool>(ctx);
+  const auto delimiter        = static_cast<char>(argument::get_next_scalar<int32_t>(ctx));
+  const auto nbytes           = argument::get_next_scalar_vector<size_t>(ctx);
+  const auto nbytes_total     = argument::get_next_scalar<size_t>(ctx);
+  const auto read_header      = argument::get_next_scalar<bool>(ctx);
+  PhysicalTable tbl_arg       = argument::get_next_output<PhysicalTable>(ctx);
+  argument::get_parallel_launch_task(ctx);
+
+  if (file_paths.size() != nbytes.size()) {
+    throw std::runtime_error("internal error: file path and nbytes size mismatch");
   }
 
-  static void gpu_variant(legate::TaskContext context)
-  {
-    TaskContext ctx{context};
-    const std::string dirpath  = argument::get_next_scalar<std::string>(ctx);
-    const auto column_names    = argument::get_next_scalar_vector<std::string>(ctx);
-    const auto tbl             = argument::get_next_input<PhysicalTable>(ctx);
-    const std::string filepath = dirpath + "/part." + std::to_string(ctx.rank) + ".csv";
-    const auto delimiter       = static_cast<char>(argument::get_next_scalar<int32_t>(ctx));
+  auto dtypes = tbl_arg.arrow_types();
 
-    auto dest    = cudf::io::sink_info(filepath);
-    auto options = cudf::io::csv_writer_options::builder(dest, tbl.table_view());
-    options.names(column_names);
-    options.inter_column_delimiter(delimiter);
-
-    cudf::io::write_csv(options, ctx.stream());
+  std::vector<std::string> include_columns;
+  for (auto index : use_cols_indexes) {
+    include_columns.push_back("f" + std::to_string(index));
   }
-};
-
-class CSVRead : public Task<CSVRead, OpCode::CSVRead> {
- public:
-  static void cpu_variant(legate::TaskContext context)
-  {
-    TaskContext ctx{context};
-    const auto launch_domain    = context.get_launch_domain();
-    const auto file_paths       = argument::get_next_scalar_vector<std::string>(ctx);
-    const auto all_column_names = argument::get_next_scalar_vector<std::string>(ctx);
-    const auto use_cols_indexes = argument::get_next_scalar_vector<int>(ctx);
-    const auto na_filter        = argument::get_next_scalar<bool>(ctx);
-    const auto delimiter        = static_cast<char>(argument::get_next_scalar<int32_t>(ctx));
-    const auto nbytes           = argument::get_next_scalar_vector<size_t>(ctx);
-    const auto nbytes_total     = argument::get_next_scalar<size_t>(ctx);
-    const auto read_header      = argument::get_next_scalar<bool>(ctx);
-    PhysicalTable tbl_arg       = argument::get_next_output<PhysicalTable>(ctx);
-    argument::get_parallel_launch_task(ctx);
-
-    if (file_paths.size() != nbytes.size()) {
-      throw std::runtime_error("internal error: file path and nbytes size mismatch");
-    }
-
-    auto dtypes = tbl_arg.arrow_types();
-
-    std::vector<std::string> include_columns;
-    for (auto index : use_cols_indexes) {
-      include_columns.push_back("f" + std::to_string(index));
-    }
-    std::unordered_map<std::string, std::shared_ptr<arrow::DataType>> dtypes_map;
-    for (size_t i = 0; i < dtypes.size(); i++) {
-      dtypes_map[include_columns[i]] = dtypes[i];
-    }
-
-    // Assign one file to each rank for now
-    auto [file_offset, num_files] = evenly_partition_work(file_paths.size(), ctx.rank, ctx.nranks);
-    std::vector<std::shared_ptr<arrow::Table>> tables;
-    for (size_t i = file_offset; i < file_offset + num_files; i++) {
-      auto input = ARROW_RESULT(arrow::io::ReadableFile::Open(file_paths[i]));
-
-      auto read_options        = arrow::csv::ReadOptions::Defaults();
-      read_options.use_threads = false;
-      // Column names will be f0, f1 ...
-      read_options.autogenerate_column_names = true;
-      read_options.skip_rows                 = read_header ? 1 : 0;
-
-      auto parse_options              = arrow::csv::ParseOptions::Defaults();
-      parse_options.delimiter         = delimiter;
-      auto convert_options            = arrow::csv::ConvertOptions::Defaults();
-      convert_options.column_types    = dtypes_map;
-      convert_options.include_columns = include_columns;
-
-      // Instantiate TableReader from input stream and options
-      arrow::io::IOContext io_context                 = arrow::io::default_io_context();
-      std::shared_ptr<arrow::csv::TableReader> reader = ARROW_RESULT(arrow::csv::TableReader::Make(
-        io_context, input, read_options, parse_options, convert_options));
-
-      // Read table from CSV file
-      auto result = reader->Read();
-      if (!result.ok()) {
-        // Empty file
-        if (result.status().ToString().find("Empty CSV file") != std::string::npos) {
-          continue;
-        } else {
-          throw std::runtime_error("Failed to read CSV file: " + result.status().ToString());
-        }
-      }
-      tables.push_back(*result);
-    }
-
-    // Concatenate tables
-    if (tables.size() == 0) {
-      tbl_arg.bind_empty_data();
-    } else {
-      auto table = ARROW_RESULT(arrow::ConcatenateTables(tables));
-      tbl_arg.move_into(table);
-    }
+  std::unordered_map<std::string, std::shared_ptr<arrow::DataType>> dtypes_map;
+  for (size_t i = 0; i < dtypes.size(); i++) {
+    dtypes_map[include_columns[i]] = dtypes[i];
   }
 
-  static void gpu_variant(legate::TaskContext context)
-  {
-    TaskContext ctx{context};
-    const auto file_paths       = argument::get_next_scalar_vector<std::string>(ctx);
-    const auto column_names     = argument::get_next_scalar_vector<std::string>(ctx);
-    const auto use_cols_indexes = argument::get_next_scalar_vector<int>(ctx);
-    const auto na_filter        = argument::get_next_scalar<bool>(ctx);
-    const auto delimiter        = static_cast<char>(argument::get_next_scalar<int32_t>(ctx));
-    const auto nbytes           = argument::get_next_scalar_vector<size_t>(ctx);
-    const auto nbytes_total     = argument::get_next_scalar<size_t>(ctx);
-    const auto read_header      = argument::get_next_scalar<bool>(ctx);
-    PhysicalTable tbl_arg       = argument::get_next_output<PhysicalTable>(ctx);
-    argument::get_parallel_launch_task(ctx);
+  // Assign one file to each rank for now
+  auto [file_offset, num_files] = evenly_partition_work(file_paths.size(), ctx.rank, ctx.nranks);
+  std::vector<std::shared_ptr<arrow::Table>> tables;
+  for (size_t i = file_offset; i < file_offset + num_files; i++) {
+    auto input = ARROW_RESULT(arrow::io::ReadableFile::Open(file_paths[i]));
 
-    if (file_paths.size() != nbytes.size()) {
-      throw std::runtime_error("internal error: file path and nbytes size mismatch");
-    }
+    auto read_options        = arrow::csv::ReadOptions::Defaults();
+    read_options.use_threads = false;
+    // Column names will be f0, f1 ...
+    read_options.autogenerate_column_names = true;
+    read_options.skip_rows                 = read_header ? 1 : 0;
 
-    auto [my_bytes_offset, my_num_bytes] =
-      evenly_partition_work(nbytes_total, ctx.rank, ctx.nranks);
+    auto parse_options              = arrow::csv::ParseOptions::Defaults();
+    parse_options.delimiter         = delimiter;
+    auto convert_options            = arrow::csv::ConvertOptions::Defaults();
+    convert_options.column_types    = dtypes_map;
+    convert_options.include_columns = include_columns;
 
-    auto dtypes = tbl_arg.cudf_types();
+    // Instantiate TableReader from input stream and options
+    arrow::io::IOContext io_context                 = arrow::io::default_io_context();
+    std::shared_ptr<arrow::csv::TableReader> reader = ARROW_RESULT(arrow::csv::TableReader::Make(
+      io_context, input, read_options, parse_options, convert_options));
 
-    std::map<std::string, cudf::data_type> dtypes_map;
-    for (size_t i = 0; i < dtypes.size(); i++) {
-      dtypes_map[column_names[i]] = dtypes[i];
-    }
-
-    // Iterate through the file and nrow list and read as many rows from the
-    // files as this rank should read while skipping those of the other tasks.
-    std::vector<std::unique_ptr<cudf::table>> tables;
-    size_t total_bytes_seen = 0;
-    for (size_t i = 0; i < file_paths.size() && my_num_bytes > 0; i++) {
-      auto file_bytes = nbytes[i];
-
-      if (total_bytes_seen + file_bytes <= my_bytes_offset) {
-        // All of this files bytes belong to earlier ranks.
-        total_bytes_seen += file_bytes;
+    // Read table from CSV file
+    auto result = reader->Read();
+    if (!result.ok()) {
+      // Empty file
+      if (result.status().ToString().find("Empty CSV file") != std::string::npos) {
         continue;
+      } else {
+        throw std::runtime_error("Failed to read CSV file: " + result.status().ToString());
       }
-      // Calculate offset and bytes to read from this file.
-      auto file_bytes_offset  = my_bytes_offset - total_bytes_seen;
-      auto file_bytes_to_read = std::min(file_bytes - file_bytes_offset, my_num_bytes);
-
-      auto src = cudf::io::source_info(file_paths[i]);
-      auto opt = cudf::io::csv_reader_options::builder(src);
-      if (file_bytes_offset != 0 || !read_header) {
-        // Reading the header makes only sense at the start of a file
-        // TODO: If the header is read, could sanity check columns for multiple files.
-        opt.header(-1);
-      }
-      opt.delimiter(delimiter);
-      opt.na_filter(na_filter);
-      opt.dtypes(dtypes_map);
-      opt.byte_range_offset(file_bytes_offset);
-      opt.byte_range_size(file_bytes_to_read);
-      opt.use_cols_indexes(use_cols_indexes);
-      opt.names(column_names);
-
-      auto read_table = cudf::io::read_csv(opt, ctx.stream(), ctx.mr()).tbl;
-
-      // Only add if we read something (otherwise number of cols may be off)
-      if (read_table->num_rows() != 0) { tables.emplace_back(std::move(read_table)); }
-
-      // Reading may read additional bytes at the end and less at the start
-      // However, there is no need to worry about the actual bytes read,
-      // we only worry how much we try to read from the next file.
-      my_num_bytes -= file_bytes_to_read;
-      my_bytes_offset += file_bytes_to_read;
-      total_bytes_seen += file_bytes;
     }
-
-    // Concatenate tables and move the result to the output table
-    if (tables.size() == 0) {
-      tbl_arg.bind_empty_data();
-    } else if (tables.size() == 1) {
-      tbl_arg.move_into(std::move(tables.back()));
-    } else {
-      std::vector<cudf::table_view> table_views;
-      for (const auto& table : tables) {
-        table_views.push_back(table->view());
-      }
-      tbl_arg.move_into(cudf::concatenate(table_views, ctx.stream(), ctx.mr()));
-    }
+    tables.push_back(*result);
   }
-};
+
+  // Concatenate tables
+  if (tables.size() == 0) {
+    tbl_arg.bind_empty_data();
+  } else {
+    auto table = ARROW_RESULT(arrow::ConcatenateTables(tables));
+    tbl_arg.move_into(table);
+  }
+}
 
 }  // namespace legate::dataframe::task
 

--- a/cpp/src/csv.cpp
+++ b/cpp/src/csv.cpp
@@ -162,7 +162,7 @@ void csv_write(LogicalTable& tbl, const std::string& dirpath, char delimiter)
 }
 
 LogicalTable csv_read(const std::vector<std::string>& files,
-                      const std::vector<cudf::data_type>& dtypes,
+                      const std::vector<std::shared_ptr<arrow::DataType>>& dtypes,
                       bool na_filter,
                       char delimiter,
                       const std::optional<std::vector<std::string>>& names,

--- a/cpp/src/csv.cu
+++ b/cpp/src/csv.cu
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2024-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <filesystem>
+#include <fstream>
+#include <stdexcept>
+#include <vector>
+
+#include <cudf/concatenate.hpp>
+#include <cudf/io/csv.hpp>
+#include <legate.h>
+#include <rmm/device_buffer.hpp>
+
+#include <legate_dataframe/core/column.hpp>
+#include <legate_dataframe/core/library.hpp>
+#include <legate_dataframe/core/table.hpp>
+#include <legate_dataframe/core/task_context.hpp>
+
+#include <legate_dataframe/csv.hpp>
+
+namespace legate::dataframe::task {
+
+/*static*/ void CSVWrite::gpu_variant(legate::TaskContext context)
+{
+  TaskContext ctx{context};
+  const std::string dirpath  = argument::get_next_scalar<std::string>(ctx);
+  const auto column_names    = argument::get_next_scalar_vector<std::string>(ctx);
+  const auto tbl             = argument::get_next_input<PhysicalTable>(ctx);
+  const std::string filepath = dirpath + "/part." + std::to_string(ctx.rank) + ".csv";
+  const auto delimiter       = static_cast<char>(argument::get_next_scalar<int32_t>(ctx));
+
+  auto dest    = cudf::io::sink_info(filepath);
+  auto options = cudf::io::csv_writer_options::builder(dest, tbl.table_view());
+  options.names(column_names);
+  options.inter_column_delimiter(delimiter);
+
+  cudf::io::write_csv(options, ctx.stream());
+}
+
+/* static */ void CSVRead::gpu_variant(legate::TaskContext context)
+{
+  TaskContext ctx{context};
+  const auto file_paths       = argument::get_next_scalar_vector<std::string>(ctx);
+  const auto column_names     = argument::get_next_scalar_vector<std::string>(ctx);
+  const auto use_cols_indexes = argument::get_next_scalar_vector<int>(ctx);
+  const auto na_filter        = argument::get_next_scalar<bool>(ctx);
+  const auto delimiter        = static_cast<char>(argument::get_next_scalar<int32_t>(ctx));
+  const auto nbytes           = argument::get_next_scalar_vector<size_t>(ctx);
+  const auto nbytes_total     = argument::get_next_scalar<size_t>(ctx);
+  const auto read_header      = argument::get_next_scalar<bool>(ctx);
+  PhysicalTable tbl_arg       = argument::get_next_output<PhysicalTable>(ctx);
+  argument::get_parallel_launch_task(ctx);
+
+  if (file_paths.size() != nbytes.size()) {
+    throw std::runtime_error("internal error: file path and nbytes size mismatch");
+  }
+
+  auto [my_bytes_offset, my_num_bytes] = evenly_partition_work(nbytes_total, ctx.rank, ctx.nranks);
+
+  auto dtypes = tbl_arg.cudf_types();
+
+  std::map<std::string, cudf::data_type> dtypes_map;
+  for (size_t i = 0; i < dtypes.size(); i++) {
+    dtypes_map[column_names[i]] = dtypes[i];
+  }
+
+  // Iterate through the file and nrow list and read as many rows from the
+  // files as this rank should read while skipping those of the other tasks.
+  std::vector<std::unique_ptr<cudf::table>> tables;
+  size_t total_bytes_seen = 0;
+  for (size_t i = 0; i < file_paths.size() && my_num_bytes > 0; i++) {
+    auto file_bytes = nbytes[i];
+
+    if (total_bytes_seen + file_bytes <= my_bytes_offset) {
+      // All of this files bytes belong to earlier ranks.
+      total_bytes_seen += file_bytes;
+      continue;
+    }
+    // Calculate offset and bytes to read from this file.
+    auto file_bytes_offset  = my_bytes_offset - total_bytes_seen;
+    auto file_bytes_to_read = std::min(file_bytes - file_bytes_offset, my_num_bytes);
+
+    auto src = cudf::io::source_info(file_paths[i]);
+    auto opt = cudf::io::csv_reader_options::builder(src);
+    if (file_bytes_offset != 0 || !read_header) {
+      // Reading the header makes only sense at the start of a file
+      // TODO: If the header is read, could sanity check columns for multiple files.
+      opt.header(-1);
+    }
+    opt.delimiter(delimiter);
+    opt.na_filter(na_filter);
+    opt.dtypes(dtypes_map);
+    opt.byte_range_offset(file_bytes_offset);
+    opt.byte_range_size(file_bytes_to_read);
+    opt.use_cols_indexes(use_cols_indexes);
+    opt.names(column_names);
+
+    auto read_table = cudf::io::read_csv(opt, ctx.stream(), ctx.mr()).tbl;
+
+    // Only add if we read something (otherwise number of cols may be off)
+    if (read_table->num_rows() != 0) { tables.emplace_back(std::move(read_table)); }
+
+    // Reading may read additional bytes at the end and less at the start
+    // However, there is no need to worry about the actual bytes read,
+    // we only worry how much we try to read from the next file.
+    my_num_bytes -= file_bytes_to_read;
+    my_bytes_offset += file_bytes_to_read;
+    total_bytes_seen += file_bytes;
+  }
+
+  // Concatenate tables and move the result to the output table
+  if (tables.size() == 0) {
+    tbl_arg.bind_empty_data();
+  } else if (tables.size() == 1) {
+    tbl_arg.move_into(std::move(tables.back()));
+  } else {
+    std::vector<cudf::table_view> table_views;
+    for (const auto& table : tables) {
+      table_views.push_back(table->view());
+    }
+    tbl_arg.move_into(cudf::concatenate(table_views, ctx.stream(), ctx.mr()));
+  }
+}
+
+}  // namespace legate::dataframe::task

--- a/cpp/src/reduction.cpp
+++ b/cpp/src/reduction.cpp
@@ -418,7 +418,8 @@ class AggregationHelper final {
       auto sum        = get_result("sum", output_type, std::nullopt);
       auto cudf_int64 = cudf::data_type{cudf::type_id::INT64};
       auto counts     = get_result("count_valid", cudf_int64, std::nullopt);
-      return legate::dataframe::binary_operation(sum, counts, "divide", output_type);
+      return legate::dataframe::binary_operation(
+        sum, counts, "divide", to_arrow_type(output_type.id()));
     } else {
       auto first_pass_res = get_first_pass_result(op, output_type);
       return perform_simple_reduce(first_pass_res, op, /* finalize */ true, output_type, initial);

--- a/cpp/tests/test_csv.cpp
+++ b/cpp/tests/test_csv.cpp
@@ -46,7 +46,7 @@ TYPED_TEST(NumericCSVTest, ReadWrite)
   //     in order to wait until all files has been written to disk.
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
-  auto dtype = cudf::data_type{cudf::type_to_id<TypeParam>()};
+  auto dtype = a.arrow_type();
   auto files = parse_glob(tmp_dir.path() / "*.csv");
   auto tbl_b = csv_read(files, {dtype, dtype}, false);
 
@@ -68,7 +68,7 @@ TYPED_TEST(NumericCSVTest, ReadWriteSingleItem)
   //     in order to wait until all files has been written to disk.
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
-  auto dtype = cudf::data_type{cudf::type_to_id<TypeParam>()};
+  auto dtype = a.arrow_type();
   auto files = parse_glob(tmp_dir.path() / "*.csv");
   auto tbl_b = csv_read(files, {dtype}, false);
 
@@ -90,7 +90,7 @@ TEST(StringsCSVTest, ReadWrite)
   //     in order to wait until all files has been written to disk.
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
-  auto dtype = tbl_a.get_column(0).cudf_type();
+  auto dtype = tbl_a.get_column(0).arrow_type();
   auto files = parse_glob(tmp_dir.path() / "*.csv");
   auto tbl_b = csv_read(files, {dtype}, false);
 
@@ -111,7 +111,7 @@ TYPED_TEST(NumericCSVTest, ReadNulls)
   //     in order to wait until all files has been written to disk.
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
-  auto dtype = cudf::data_type{cudf::type_to_id<TypeParam>()};
+  auto dtype = a.arrow_type();
   auto files = parse_glob(tmp_dir.path() / "*.csv");
   auto tbl_b = csv_read(files, {dtype, dtype}, true);
 
@@ -132,7 +132,7 @@ TYPED_TEST(NumericCSVTest, ReadUseCols)
   //     in order to wait until all files has been written to disk.
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
-  auto dtype = cudf::data_type{cudf::type_to_id<TypeParam>()};
+  auto dtype = a.arrow_type();
   std::vector<std::string> usecols1({"a", "b"});
   auto files = parse_glob(tmp_dir.path() / "*.csv");
   auto tbl_b = csv_read(files, {dtype, dtype}, true, ',', usecols1);
@@ -161,7 +161,7 @@ TYPED_TEST(NumericCSVTest, ReadWriteWithDelimiter)
   //     in order to wait until all files has been written to disk.
   legate::Runtime::get_runtime()->issue_execution_fence(true);
 
-  auto dtype = cudf::data_type{cudf::type_to_id<TypeParam>()};
+  auto dtype = a.arrow_type();
   auto files = parse_glob(tmp_dir.path() / "*.csv");
   auto tbl_b = csv_read(files, {dtype, dtype}, false, '|');
 

--- a/python/legate_dataframe/lib/binaryop.pyx
+++ b/python/legate_dataframe/lib/binaryop.pyx
@@ -4,12 +4,13 @@
 # distutils: language = c++
 # cython: language_level=3
 
+from libcpp.memory cimport shared_ptr
 from libcpp.string cimport string
 
-from pylibcudf.types cimport data_type
+from pyarrow.lib cimport CDataType
 
 from legate_dataframe.lib.core.column cimport LogicalColumn, cpp_LogicalColumn
-from legate_dataframe.lib.core.data_type cimport as_data_type
+from legate_dataframe.lib.core.data_type cimport as_arrow_data_type
 from legate_dataframe.lib.core.scalar cimport cpp_scalar_col_from_python
 
 from numpy.typing import DTypeLike
@@ -22,7 +23,7 @@ cdef extern from "<legate_dataframe/binaryop.hpp>" nogil:
         const cpp_LogicalColumn& lhs,
         const cpp_LogicalColumn& rhs,
         string op,
-        data_type output_type
+        shared_ptr[CDataType] output_type
     )
 
 
@@ -89,6 +90,6 @@ def binary_operation(
     return LogicalColumn.from_handle(
         cpp_binary_operation(
             lhs_col._handle, rhs_col._handle, op.encode('utf-8'),
-            as_data_type(output_type)
+            as_arrow_data_type(output_type)
         )
     )

--- a/python/legate_dataframe/lib/core/data_type.pxd
+++ b/python/legate_dataframe/lib/core/data_type.pxd
@@ -4,11 +4,16 @@
 # distutils: language = c++
 # cython: language_level=3
 
+from libcpp.memory cimport shared_ptr
+
+from pyarrow.lib cimport CDataType
 from pylibcudf.types cimport DataType
 from pylibcudf.types cimport data_type as cpp_cudf_type
 
 
 cdef cpp_cudf_type as_data_type(data_type_like)
+
+cdef shared_ptr[CDataType] as_arrow_data_type(data_type_like)
 
 cdef cpp_cudf_type_to_cudf_dtype(cpp_cudf_type libcudf_type)
 

--- a/python/legate_dataframe/lib/core/data_type.pyx
+++ b/python/legate_dataframe/lib/core/data_type.pyx
@@ -45,10 +45,15 @@ cdef shared_ptr[CDataType] as_arrow_data_type(data_type_like):
         return d_type
 
     # try numpy dtype
-    d_type = pyarrow_unwrap_data_type(
-        pa.from_numpy_dtype(data_type_like)
-    )
-    return d_type
+    try:
+        d_type = pyarrow_unwrap_data_type(
+            pa.from_numpy_dtype(data_type_like)
+        )
+        return d_type
+    except Exception as e:
+        raise TypeError(
+            f"Cannot convert {data_type_like} to an arrow data type."
+        ) from e
 
 
 cdef cpp_cudf_type as_data_type(data_type_like):


### PR DESCRIPTION
Start with binaryop and readcsv. Split into .cu and .cpp files to prepare for cpu only compilation. Also change cudf data types to arrow data types in function signature.