### PR TITLE
Expose datetime component to polars and fix true-divide

### DIFF
--- a/cpp/src/binaryop.cu
+++ b/cpp/src/binaryop.cu
@@ -37,6 +37,7 @@ cudf::binary_operator arrow_to_cudf_binary_op(std::string op, legate::Type outpu
   // https://docs.rapids.ai/api/libcudf/stable/group__transformation__binaryops
   std::unordered_map<std::string, cudf::binary_operator> arrow_to_cudf_ops = {
     {"add", cudf::binary_operator::ADD},
+    // NOTE: if we enable true divide here, should improve polars side.
     {"divide", cudf::binary_operator::DIV},
     {"multiply", cudf::binary_operator::MUL},
     {"power", cudf::binary_operator::POW},

--- a/cpp/src/parquet.cpp
+++ b/cpp/src/parquet.cpp
@@ -250,6 +250,9 @@ class ParquetRead : public Task<ParquetRead, OpCode::ParquetRead> {
     auto opt = cudf::io::parquet_reader_options::builder(src);
     opt.columns(columns);
     opt.row_groups(row_groups);
+    // If pandas metadata is read, libcudf may read index columns without this.
+    opt.use_pandas_metadata(false);
+
     auto res = cudf::io::read_parquet(opt, ctx.stream(), ctx.mr()).tbl;
 
     if (get_prefer_eager_allocations()) {

--- a/python/legate_dataframe/ldf_polars/__init__.py
+++ b/python/legate_dataframe/ldf_polars/__init__.py
@@ -45,7 +45,7 @@ def lazy_from_legate_df(df):
 
     # Last False (within polars) changes the predicate to be passed for arrow.
     plf = PyLazyFrame.scan_from_python_function_pl_schema(
-        schema, partial(_create_df, df), False
+        schema, partial(_create_df, df), False, validate_schema=True
     )
 
     return pl.LazyFrame._from_pyldf(plf)

--- a/python/legate_dataframe/ldf_polars/dsl/expr.py
+++ b/python/legate_dataframe/ldf_polars/dsl/expr.py
@@ -27,7 +27,7 @@ from legate_dataframe.ldf_polars.dsl.expressions.base import (
 from legate_dataframe.ldf_polars.dsl.expressions.binaryop import BinOp
 
 # from legate_dataframe.ldf_polars.dsl.expressions.boolean import BooleanFunction
-# from legate_dataframe.ldf_polars.dsl.expressions.datetime import TemporalFunction
+from legate_dataframe.ldf_polars.dsl.expressions.datetime import TemporalFunction
 from legate_dataframe.ldf_polars.dsl.expressions.literal import Literal, LiteralColumn
 
 # from legate_dataframe.ldf_polars.dsl.expressions.rolling import GroupedRollingWindow, RollingWindow
@@ -61,7 +61,7 @@ __all__ = [
     # "Sort",
     # "SortBy",
     # "StringFunction",
-    # "TemporalFunction",
+    "TemporalFunction",
     # "Ternary",
     "UnaryFunction",
 ]

--- a/python/legate_dataframe/ldf_polars/dsl/translate.py
+++ b/python/legate_dataframe/ldf_polars/dsl/translate.py
@@ -505,7 +505,28 @@ def _(
             f"BooleanFunction {name} not supported (only IsBetween is)"
         )
     elif isinstance(name, pl_expr.TemporalFunction):
-        raise NotImplementedError("TemporalFunction not supported")
+        # functions for which evaluation of the expression may not return
+        # the same dtype as polars, either due to libcudf returning a different
+        # dtype, or due to our internal processing affecting what libcudf returns
+        needs_cast = {
+            pl_expr.TemporalFunction.Year,
+            pl_expr.TemporalFunction.Month,
+            pl_expr.TemporalFunction.Day,
+            pl_expr.TemporalFunction.WeekDay,
+            pl_expr.TemporalFunction.Hour,
+            pl_expr.TemporalFunction.Minute,
+            pl_expr.TemporalFunction.Second,
+            pl_expr.TemporalFunction.Millisecond,
+        }
+        result_expr = expr.TemporalFunction(
+            dtype,
+            expr.TemporalFunction.Name.from_polars(name),
+            options,
+            *(translator.translate_expr(n=n, schema=schema) for n in node.input),
+        )
+        if name in needs_cast:
+            return expr.Cast(dtype, result_expr)
+        return result_expr
 
     elif isinstance(name, str):
         children = (translator.translate_expr(n=n, schema=schema) for n in node.input)

--- a/python/legate_dataframe/ldf_polars/utils/dtypes.py
+++ b/python/legate_dataframe/ldf_polars/utils/dtypes.py
@@ -263,6 +263,18 @@ def to_polars(dtype) -> pl.DataType:
         return pl.Float64
     elif type_id == plc.TypeId.TIMESTAMP_DAYS:
         return pl.Date
+    elif type_id == plc.TypeId.TIMESTAMP_MILLISECONDS:
+        return pl.Datetime(time_unit="ms")
+    elif type_id == plc.TypeId.TIMESTAMP_MICROSECONDS:
+        return pl.Datetime(time_unit="us")
+    elif type_id == plc.TypeId.TIMESTAMP_NANOSECONDS:
+        return pl.Datetime(time_unit="ns")
+    elif type_id == plc.TypeId.DURATION_MILLISECONDS:
+        return pl.Duration(time_unit="ms")
+    elif type_id == plc.TypeId.DURATION_MICROSECONDS:
+        return pl.Duration(time_unit="us")
+    elif type_id == plc.TypeId.DURATION_NANOSECONDS:
+        return pl.Duration(time_unit="ns")
     elif type_id == plc.TypeId.STRING:
         return pl.String
 

--- a/python/legate_dataframe/lib/timestamps.pyx
+++ b/python/legate_dataframe/lib/timestamps.pyx
@@ -24,12 +24,12 @@ cdef extern from "<legate_dataframe/timestamps.hpp>" namespace "legate::datafram
         const cpp_LogicalColumn& input,
         data_type timestamp_type,
         string format,
-    )
+    ) except +
 
     cpp_LogicalColumn cpp_extract_timestamp_component "extract_timestamp_component"(
         const cpp_LogicalColumn& input,
         datetime_component component,
-    )
+    ) except +
 
 
 @_track_provenance

--- a/python/tests/test_binaryop.py
+++ b/python/tests/test_binaryop.py
@@ -107,7 +107,20 @@ def test_scalar_input(array, op, scalar):
     assert result.is_scalar()  # if both inputs are scalar, the result is also
 
 
-operators = ["add", "sub", "mul", "and_", "or_", "eq", "ne", "lt", "le", "gt", "ge"]
+operators = [
+    "add",
+    "sub",
+    "mul",
+    "truediv",
+    "and_",
+    "or_",
+    "eq",
+    "ne",
+    "lt",
+    "le",
+    "gt",
+    "ge",
+]
 
 
 @pytest.mark.parametrize("op", operators)
@@ -129,6 +142,24 @@ def test_binary_operation_polars(op):
         a_b=getattr(operator, op)(pl.col("a"), pl.col("b"))
     )
     assert_matches_polars(q)
+
+
+def test_true_div_polars():
+    # Basic check that true division does the right promotion to float.
+    pl = pytest.importorskip("polars")
+
+    df = pl.DataFrame(
+        {
+            "a": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            "b": [1, -2, 3, -4, 5, -6, 7, -8, 9, -10],
+        }
+    )
+    q = df.lazy().with_columns(
+        res1=pl.col("a") / pl.col("b"),
+        res2=pl.col("a") / 3,
+        res3=3 / pl.col("a"),
+    )
+    assert_matches_polars(q, approx=True)
 
 
 @pytest.mark.parametrize("mode", ["none", "left", "right", "both"])


### PR DESCRIPTION
We should still expose datetime component extraction for CPU as well probably, that might change things, but hopefully too annoyingly so.

I think true-divide (at least for polars) is main useful thing, while divide I believe is a floor-divide, which we could expose but only easily for non-floats probably.
So, hacked true-divide to work, although one day we may want to lower that.
