### PR TITLE
DOC: Add a note about polars support to docs

### DIFF
--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -12,3 +12,4 @@ Python API Reference
    table_funcs
    column
    table
+   polars

--- a/docs/source/api/polars.rst
+++ b/docs/source/api/polars.rst
@@ -1,0 +1,38 @@
+Polars support
+==============
+
+Legate-dataframe has support for integrating with polars.
+To enable this support it is currently necessary to include::
+
+    import legate_dataframe.ldf_polars  # noqa: F401
+
+This will enable the ability call::
+
+    polars_lazy_frame.legate.collect()
+
+A minimal example may be::
+
+    q = pl.scan_csv("mydata.csv")
+    q = q.with_columns(...)  # work with q
+    legate_result = q.legate.collect()
+
+which executes the polars query to return a legate-dataframe
+`~legate_dataframe.lib.core.table.LogicalTable`.
+
+As of now, we do not hook into polars' ``collect``, nor does
+legate-dataframe's ``collect`` currently fall back to polars when an
+operation is unsupported.
+The solution will either fully execute in a distributed manner within
+legate-dataframe or an error will be raised.
+
+If you wish to convert a ``LogicalTable`` to a ``polars.Dataframe``
+you may do so via ``polars.from_arrow(legate_table.to_arrow())``.
+A ``LogicalTable`` may also be converted to a polars ``LazyFrame`` via
+``LogicalTable.lazy()``, however, such a ``LazyFrame`` can only be
+collected via ``.legate.collect()``.
+
+.. note::
+    The exact integration path may change in the future to use
+    the polars engine more like ``cudf-polars``.
+    The current approach exists mainly to allow the return of a
+    ``LogicalTable`` object.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,8 +5,8 @@ Welcome to the legate-dataframe documentation
 ``legate-dataframe`` is a prototype of a legate-enabled version of libcudf.
 This is not a drop-in replacement of Pandas, instead it follows the low-level API of libcudf.
 
-In the future, we plan to introduce a high-level and user friendly Python package
-using these low-level API's primitives.
+``legate-dataframe`` has some support for the polars ``LazyFrame`` api as described
+in `api/polars.rst`.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
This adds a brief note about polars support to the docs. Since (almost) all functionality is exposed as such, I think we can do that.

The exact way of exposure should likely still change admittedly. It would be nice to integrate as an `engine` like cudf-polars does.

(I have not looked at it much yet, because, first, for the use-cases that were discussed it seemed like we'll need the return of a `LogicalTable` and, second, the CPU work got us further away of tightly integrating with cudf-polars which would have been a good path.)