### PR TITLE
MAINT: Loosen assert slightly

### DIFF
--- a/cpp/src/core/column.cu
+++ b/cpp/src/core/column.cu
@@ -53,9 +53,9 @@ T* maybe_bind_buffer(legate::PhysicalStore store, std::size_t size)
     out = store.create_output_buffer<T, 1>(legate::Point<1>(size), true).ptr(0);
   } else {
     auto acc = store.write_accessor<T, 1>();
-    assert((store.shape<1>().hi[0] - store.shape<1>().lo[0]) == -1 ||
+    assert((store.shape<1>().hi[0] - store.shape<1>().lo[0]) <= 0 ||
            acc.accessor.is_dense_row_major(store.shape<1>()));
-    assert((store.shape<1>().hi[0] + 1 - store.shape<1>().lo[0]) == size);
+    assert((store.shape<1>().hi[0] + 1 - store.shape<1>().lo[0]) == size || size == 0);
     out = acc.ptr(store.shape<1>().lo[0]);
   }
   return out;


### PR DESCRIPTION
I am not sure why, but it seems for `size == 0` legate sometimes gives shapes with a negative range (if you subtract lo from hi), so just allow this in these asserts as they can otherwise fail.