### PR TITLE
Minimal fix to not do unnecessary broadcast on size 1 columns

### DIFF
--- a/python/legate_dataframe/ldf_polars/dsl/ir.py
+++ b/python/legate_dataframe/ldf_polars/dsl/ir.py
@@ -117,7 +117,7 @@ def broadcast(*columns: Column, target_length: int | None = None) -> list[Column
         raise NotImplementedError("broadcast not implemented")
 
     return [
-        column if column.size != 1 else broadcast_func(column, nrows)
+        column if column.size == nrows else broadcast_func(column, nrows)
         for column in columns
     ]
 


### PR DESCRIPTION
We need to properly implement broadcasting, but this is a minimal thing that the code unnecessary failed for the case where all columns (or the target) was size 1, which is unnecessary.
