### PR TITLE
Readd count-all groupby-agg (or len)

### DIFF
--- a/cpp/src/groupby_aggregation.cu
+++ b/cpp/src/groupby_aggregation.cu
@@ -56,6 +56,9 @@ std::unique_ptr<cudf::groupby_aggregation> make_groupby_aggregation(cudf::aggreg
     case cudf::aggregation::Kind::NUNIQUE: {
       return cudf::make_nunique_aggregation<cudf::groupby_aggregation>();
     }
+    case cudf::aggregation::Kind::COUNT_ALL: {
+      return cudf::make_count_aggregation<cudf::groupby_aggregation>(cudf::null_policy::INCLUDE);
+    }
     default: {
       throw std::invalid_argument("Unsupported groupby aggregation");
     }
@@ -75,10 +78,9 @@ cudf::aggregation::Kind arrow_to_cudf_aggregation(const std::string& agg_name)
     {"variance", cudf::aggregation::Kind::VARIANCE},
     {"stddev", cudf::aggregation::Kind::STD},
     {"approximate_median", cudf::aggregation::Kind::MEDIAN},
-    {"count_distinct", cudf::aggregation::Kind::NUNIQUE}};
-
-  //  {"count_all", cudf::aggregation::Kind::COUNT_ALL},
-  // "count_all" could be supported but needs some work as it has 0 inputs
+    {"count_distinct", cudf::aggregation::Kind::NUNIQUE},
+    {"count_all", cudf::aggregation::Kind::COUNT_ALL},
+  };
 
   // Don't do these as we don't support nested types at the moment
   // {"list", cudf::aggregation::Kind::COLLECT_LIST},

--- a/python/legate_dataframe/ldf_polars/dsl/expressions/unary.py
+++ b/python/legate_dataframe/ldf_polars/dsl/expressions/unary.py
@@ -70,6 +70,10 @@ class Len(Expr):
             LogicalColumn.from_cudf(cudf.Scalar(df.num_rows, dtype=self.dtype))
         )
 
+    @property
+    def agg_request(self):
+        return "count_all"
+
 
 class UnaryFunction(Expr):
     """Class representing unary functions of an expression."""

--- a/python/legate_dataframe/ldf_polars/dsl/ir.py
+++ b/python/legate_dataframe/ldf_polars/dsl/ir.py
@@ -935,10 +935,13 @@ class GroupBy(IR):
                 # Anything else, we pre-evaluate
                 col = value.evaluate(df)
 
-            col_name = columns.get(col, None)
-            if col_name is None:
-                # NOTE(seberg): May need a unique name here eventually
-                columns[col] = (col_name := name)
+            if value.agg_request == "count_all":
+                col_name = None
+            else:
+                col_name = columns.get(col, None)
+                if col_name is None:
+                    # NOTE(seberg): May need a unique name here eventually
+                    columns[col] = (col_name := name)
 
             requests.append((col_name, value.agg_request, name))
 

--- a/python/legate_dataframe/lib/groupby_aggregation.pyi
+++ b/python/legate_dataframe/lib/groupby_aggregation.pyi
@@ -8,5 +8,5 @@ from legate_dataframe.lib.core.table import LogicalTable
 def groupby_aggregation(
     table: LogicalTable,
     keys: Iterable[str],
-    column_aggregations: Iterable[Tuple[str, str, str]],
+    column_aggregations: Iterable[Tuple[str | None, str, str]],
 ) -> LogicalTable: ...

--- a/python/legate_dataframe/lib/groupby_aggregation.pyx
+++ b/python/legate_dataframe/lib/groupby_aggregation.pyx
@@ -76,6 +76,11 @@ def groupby_aggregation(
 
     cdef vector[AggTuple] aggs
     for in_col_name, kind, out_col_name in column_aggregations:
+        if kind == "count_all":
+            if in_col_name is not None:
+                raise ValueError("input column name must be `None` for 'count_all'")
+            in_col_name = ""
+
         aggs.push_back(
             AggTuple(
                 in_col_name.encode('UTF-8'),


### PR DESCRIPTION
This is a pretty important aggregation, but it's awkward that it needs no columns.
The cudf design was happy to just use any column here, but I now force the column to be `None` in Python instead and `""` in C.

This adds a bit of unfortunate cruft, but overall, I suspcect it's OK.
