### PR TITLE
Expose `copying.copy_if_else` and corresponding polars API

### DIFF
--- a/cpp/include/legate_dataframe/copying.hpp
+++ b/cpp/include/legate_dataframe/copying.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <legate.h>
+#include <legate_dataframe/core/column.hpp>
+#include <legate_dataframe/core/library.hpp>
+
+namespace legate::dataframe {
+
+namespace task {
+
+class CopyIfElseTask : public Task<CopyIfElseTask, OpCode::CopyIfElse> {
+ public:
+  static void cpu_variant(legate::TaskContext context);
+  static void gpu_variant(legate::TaskContext context);
+};
+
+}  // namespace task
+/**
+ * @brief Performs a ternary assignment operation along the columns.
+ *
+ * The result will contain the value of `cond[i] ? lhs[i] : rhs[i]`.  Both `lhs` and `rhs`
+ * may be scalar columns in which case they are broadcast against `cond`.
+ * `lhs` and `rhs` must have the same type.
+ *
+ * @param cond The condition column to decide which value to copy
+ * @param lhs  The left operand column
+ * @param rhs  The right operand column
+ * @return     The result of the ternary if_else operation.
+ * @throw      std::invalid_argument if `lhs` and `rhs` have different types or `cond`
+ *             is not boolean.
+ */
+LogicalColumn copy_if_else(const LogicalColumn& cond,
+                           const LogicalColumn& lhs,
+                           const LogicalColumn& rhs);
+
+}  // namespace legate::dataframe

--- a/cpp/include/legate_dataframe/core/library.hpp
+++ b/cpp/include/legate_dataframe/core/library.hpp
@@ -31,6 +31,7 @@ enum : int {
   CSVWrite,
   CSVRead,
   Cast,
+  CopyIfElse,
   ParquetWrite,
   ParquetRead,
   ParquetReadArray,

--- a/cpp/src/copying.cpp
+++ b/cpp/src/copying.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <arrow/compute/api.h>
+#include <legate_dataframe/copying.hpp>
+#include <legate_dataframe/core/column.hpp>
+#include <legate_dataframe/core/library.hpp>
+#include <legate_dataframe/core/table.hpp>
+#include <legate_dataframe/core/task_argument.hpp>
+#include <legate_dataframe/core/task_context.hpp>
+
+namespace legate::dataframe::task {
+
+/*static*/ void CopyIfElseTask::cpu_variant(legate::TaskContext context)
+{
+  TaskContext ctx{context};
+  const auto cond = argument::get_next_input<PhysicalColumn>(ctx);
+  const auto lhs  = argument::get_next_input<PhysicalColumn>(ctx);
+  const auto rhs  = argument::get_next_input<PhysicalColumn>(ctx);
+  auto output     = argument::get_next_output<PhysicalColumn>(ctx);
+
+  std::vector<arrow::Datum> args;
+  args.reserve(3);
+  for (auto& column : {&cond, &lhs, &rhs}) {
+    if (column->num_rows() == 1) {
+      auto scalar = ARROW_RESULT(column->arrow_array_view()->GetScalar(0));
+      args.emplace_back(scalar);
+    } else {
+      args.emplace_back(column->arrow_array_view());
+    }
+  }
+
+  // Result may be scalar or array
+  auto datum_result = ARROW_RESULT(arrow::compute::CallFunction("if_else", args));
+
+  if (datum_result.is_scalar()) {
+    auto as_array = ARROW_RESULT(arrow::MakeArrayFromScalar(*datum_result.scalar(), 1));
+    if (get_prefer_eager_allocations()) {
+      output.copy_into(std::move(as_array));
+    } else {
+      output.move_into(std::move(as_array));
+    }
+  } else {
+    if (get_prefer_eager_allocations()) {
+      output.copy_into(std::move(datum_result.make_array()));
+    } else {
+      output.move_into(std::move(datum_result.make_array()));
+    }
+  }
+}
+
+}  // namespace legate::dataframe::task
+
+namespace {
+
+void __attribute__((constructor)) register_tasks()
+{
+  legate::dataframe::task::CopyIfElseTask::register_variants();
+}
+
+}  // namespace
+
+namespace legate::dataframe {
+
+LogicalColumn copy_if_else(const LogicalColumn& cond,
+                           const LogicalColumn& lhs,
+                           const LogicalColumn& rhs)
+{
+  if (*lhs.arrow_type() != *rhs.arrow_type()) {
+    throw std::invalid_argument("lhs and rhs must have the same type");
+  }
+  if (*cond.arrow_type() != *arrow::boolean()) {
+    throw std::invalid_argument("cond must be a boolean column");
+  }
+
+  auto runtime = legate::Runtime::get_runtime();
+
+  bool nullable      = lhs.nullable() || rhs.nullable();
+  auto scalar_result = lhs.is_scalar() && rhs.is_scalar() && cond.is_scalar();
+  std::optional<size_t> size{};
+  if (get_prefer_eager_allocations()) {
+    size = std::max(lhs.num_rows(), std::max(rhs.num_rows(), cond.num_rows()));
+  }
+  auto ret = LogicalColumn::empty_like(lhs.arrow_type(), nullable, scalar_result, size);
+  legate::AutoTask task =
+    runtime->create_task(get_library(), task::CopyIfElseTask::TASK_CONFIG.task_id());
+
+  /* Add the inputs, broadcast if scalar.  If both aren't scalar align them */
+  auto cond_var = argument::add_next_input(task, cond, /* broadcast */ cond.is_scalar());
+  auto lhs_var  = argument::add_next_input(task, lhs, /* broadcast */ lhs.is_scalar());
+  auto rhs_var  = argument::add_next_input(task, rhs, /* broadcast */ rhs.is_scalar());
+  if (!lhs.is_scalar()) { task.add_constraint(legate::align(lhs_var, cond_var)); }
+  if (!rhs.is_scalar()) { task.add_constraint(legate::align(rhs_var, cond_var)); }
+  auto out_var = argument::add_next_output(task, ret);
+  if (size.has_value()) { task.add_constraint(legate::align(out_var, cond_var)); }
+  runtime->submit(std::move(task));
+  return ret;
+}
+
+}  // namespace legate::dataframe

--- a/cpp/src/copying.cu
+++ b/cpp/src/copying.cu
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <legate.h>
+
+#include <cudf/copying.hpp>
+#include <cudf/types.hpp>
+
+#include <legate_dataframe/copying.hpp>
+#include <legate_dataframe/core/column.hpp>
+#include <legate_dataframe/core/library.hpp>
+#include <legate_dataframe/core/table.hpp>
+#include <legate_dataframe/core/task_argument.hpp>
+#include <legate_dataframe/core/task_context.hpp>
+
+namespace legate::dataframe::task {
+
+/*static*/ void CopyIfElseTask::gpu_variant(legate::TaskContext context)
+{
+  TaskContext ctx{context};
+  const auto cond = argument::get_next_input<PhysicalColumn>(ctx);
+  const auto lhs  = argument::get_next_input<PhysicalColumn>(ctx);
+  const auto rhs  = argument::get_next_input<PhysicalColumn>(ctx);
+  auto output     = argument::get_next_output<PhysicalColumn>(ctx);
+
+  std::unique_ptr<cudf::column> ret;
+  /*
+   * Use scalars if inputs are to ensure broadcasting works, cond is always a column.
+   * This unfortunately requires 4 cases (all 4 overloads provided by libcudf).
+   */
+  if (lhs.num_rows() == 1 && rhs.num_rows() != 1) {
+    auto lhs_scalar = lhs.cudf_scalar();
+    ret             = cudf::copy_if_else(
+      *lhs_scalar, rhs.column_view(), cond.column_view(), ctx.stream(), ctx.mr());
+  } else if (rhs.num_rows() == 1 && lhs.num_rows() != 1) {
+    auto rhs_scalar = rhs.cudf_scalar();
+    ret             = cudf::copy_if_else(
+      lhs.column_view(), *rhs_scalar, cond.column_view(), ctx.stream(), ctx.mr());
+  } else if (lhs.num_rows() == 1 && rhs.num_rows() == 1) {
+    auto lhs_scalar = lhs.cudf_scalar();
+    auto rhs_scalar = rhs.cudf_scalar();
+    ret = cudf::copy_if_else(*lhs_scalar, *rhs_scalar, cond.column_view(), ctx.stream(), ctx.mr());
+  } else {
+    ret = cudf::copy_if_else(
+      lhs.column_view(), rhs.column_view(), cond.column_view(), ctx.stream(), ctx.mr());
+  }
+
+  if (get_prefer_eager_allocations()) {
+    output.copy_into(std::move(ret));
+  } else {
+    output.move_into(std::move(ret));
+  }
+}
+
+}  // namespace legate::dataframe::task

--- a/cpp/tests/test_copying.cpp
+++ b/cpp/tests/test_copying.cpp
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2023-2025, NVIDIA CORPORATION.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gmock/gmock-matchers.h"
+#include <arrow/api.h>
+#include <arrow/compute/api.h>
+#include <gtest/gtest.h>
+#include <legate.h>
+
+#include "test_utils.hpp"
+#include <legate_dataframe/copying.hpp>
+#include <legate_dataframe/core/column.hpp>
+
+using namespace legate::dataframe;
+
+template <typename T>
+struct CopyingTest : public testing::Test {};
+
+using CopyingTypes = ::testing::Types<int8_t, double, bool>;
+
+void CompareArrow(const LogicalColumn& cond, const LogicalColumn& lhs, const LogicalColumn& rhs)
+{
+  std::vector<arrow::Datum> args;
+  args.reserve(3);
+  for (auto& column : {&cond, &lhs, &rhs}) {
+    if (column->num_rows() == 1) {
+      auto scalar = ARROW_RESULT(column->get_arrow()->GetScalar(0));
+      args.emplace_back(scalar);
+    } else {
+      args.emplace_back(column->get_arrow());
+    }
+  }
+
+  auto expected = (ARROW_RESULT(arrow::compute::CallFunction("if_else", args))).make_array();
+  auto result   = copy_if_else(cond, lhs, rhs).get_arrow();
+
+  EXPECT_TRUE(expected->Equals(*result))
+    << "Failed copy_if_else: " << cond.repr() << " LHS: " << lhs.repr() << " RHS: " << rhs.repr()
+    << " Expected: " << expected->ToString() << " Result: " << result->ToString();
+}
+
+TYPED_TEST_SUITE(CopyingTest, CopyingTypes);
+
+TYPED_TEST(CopyingTest, ColCol)
+{
+  LogicalColumn lhs(narrow<TypeParam>({1, 2, 3, 4}));
+  LogicalColumn rhs(narrow<TypeParam>({5, 6, 7, 8}));
+  LogicalColumn cond(narrow<bool>({true, false, true, false}));
+  CompareArrow(cond, lhs, rhs);
+}
+
+TYPED_TEST(CopyingTest, ColColWithNull)
+{
+  LogicalColumn lhs(narrow<TypeParam>({1, 2, 3, 4}), {1, 0, 1, 0});
+  LogicalColumn rhs(narrow<TypeParam>({5, 6, 7, 8}), {1, 0, 1, 0});
+  LogicalColumn cond(narrow<bool>({true, true, false, false}));
+  CompareArrow(cond, lhs, rhs);
+}
+
+TYPED_TEST(CopyingTest, ColScalar)
+{
+  LogicalColumn lhs(narrow<TypeParam>({1, 2, 3, 4}));
+  LogicalColumn rhs(narrow<TypeParam>({1}), {}, true);
+  LogicalColumn cond(narrow<bool>({true, true, false, false}));
+  CompareArrow(cond, lhs, rhs);
+}
+
+TYPED_TEST(CopyingTest, ScalarCol)
+{
+  LogicalColumn lhs(narrow<TypeParam>({1}), {1}, true);
+  LogicalColumn rhs(narrow<TypeParam>({1, 2, 3, 4}));
+  LogicalColumn cond(narrow<bool>({true, true, false, false}));
+  CompareArrow(cond, lhs, rhs);
+}
+
+TYPED_TEST(CopyingTest, ScalarScalar)
+{
+  LogicalColumn lhs(narrow<TypeParam>({1}), {}, true);
+  LogicalColumn rhs(narrow<TypeParam>({2}), {}, true);
+  LogicalColumn cond(narrow<bool>({true, true, false, false}));
+  CompareArrow(cond, lhs, rhs);
+}

--- a/docs/source/api/column_funcs.rst
+++ b/docs/source/api/column_funcs.rst
@@ -14,6 +14,9 @@ Column functions
     legate_dataframe.lib.binaryop.binary_operation
 
 .. autofunction::
+    legate_dataframe.lib.copying.copy_if_else
+
+.. autofunction::
     legate_dataframe.lib.timestamps.to_timestamps
 
 .. autofunction::

--- a/python/legate_dataframe/ldf_polars/dsl/expr.py
+++ b/python/legate_dataframe/ldf_polars/dsl/expr.py
@@ -36,7 +36,7 @@ from legate_dataframe.ldf_polars.dsl.expressions.slicing import Slice
 
 # from legate_dataframe.ldf_polars.dsl.expressions.sorting import Sort, SortBy
 # from legate_dataframe.ldf_polars.dsl.expressions.string import StringFunction
-# from legate_dataframe.ldf_polars.dsl.expressions.ternary import Ternary
+from legate_dataframe.ldf_polars.dsl.expressions.ternary import Ternary
 from legate_dataframe.ldf_polars.dsl.expressions.unary import Cast, Len, UnaryFunction
 
 __all__ = [
@@ -62,6 +62,6 @@ __all__ = [
     # "SortBy",
     # "StringFunction",
     "TemporalFunction",
-    # "Ternary",
+    "Ternary",
     "UnaryFunction",
 ]

--- a/python/legate_dataframe/ldf_polars/dsl/expressions/ternary.py
+++ b/python/legate_dataframe/ldf_polars/dsl/expressions/ternary.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-License-Identifier: Apache-2.0
+# TODO: remove need for this
+# ruff: noqa: D101
+"""DSL nodes for ternary operations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pylibcudf as plc
+
+from legate_dataframe.ldf_polars.containers import Column
+from legate_dataframe.ldf_polars.dsl.expressions.base import ExecutionContext, Expr
+from legate_dataframe.lib import copying
+
+if TYPE_CHECKING:
+    from cudf_polars.containers import DataFrame
+
+
+__all__ = ["Ternary"]
+
+
+class Ternary(Expr):
+    __slots__ = ()
+    _non_child = ("dtype",)
+
+    def __init__(
+        self, dtype: plc.DataType, when: Expr, then: Expr, otherwise: Expr
+    ) -> None:
+        self.dtype = dtype
+        self.children = (when, then, otherwise)
+        self.is_pointwise = True
+
+    def do_evaluate(
+        self, df: DataFrame, *, context: ExecutionContext = ExecutionContext.FRAME
+    ) -> Column:
+        """Evaluate this expression given a dataframe for context."""
+        when, then, otherwise = (
+            child.evaluate(df, context=context) for child in self.children
+        )
+        return Column(copying.copy_if_else(when.obj, then.obj, otherwise.obj))

--- a/python/legate_dataframe/ldf_polars/dsl/translate.py
+++ b/python/legate_dataframe/ldf_polars/dsl/translate.py
@@ -662,6 +662,18 @@ def _(
 
 @_translate_expr.register
 def _(
+    node: pl_expr.Ternary, translator: Translator, dtype: plc.DataType, schema: Schema
+) -> expr.Expr:
+    return expr.Ternary(
+        dtype,
+        translator.translate_expr(n=node.predicate, schema=schema),
+        translator.translate_expr(n=node.truthy, schema=schema),
+        translator.translate_expr(n=node.falsy, schema=schema),
+    )
+
+
+@_translate_expr.register
+def _(
     node: pl_expr.BinaryExpr,
     translator: Translator,
     dtype: plc.DataType,

--- a/python/legate_dataframe/lib/CMakeLists.txt
+++ b/python/legate_dataframe/lib/CMakeLists.txt
@@ -13,8 +13,9 @@
 # =============================================================================
 
 # Set the list of Cython files to build
-set(cython_sources binaryop.pyx csv.pyx groupby_aggregation.pyx join.pyx parquet.pyx reduction.pyx
-                   replace.pyx sort.pyx stream_compaction.pyx timestamps.pyx unaryop.pyx
+set(cython_sources
+    binaryop.pyx copying.pyx csv.pyx groupby_aggregation.pyx join.pyx parquet.pyx reduction.pyx
+    replace.pyx sort.pyx stream_compaction.pyx timestamps.pyx unaryop.pyx
 )
 
 rapids_cython_create_modules(

--- a/python/legate_dataframe/lib/binaryop.pyx
+++ b/python/legate_dataframe/lib/binaryop.pyx
@@ -24,7 +24,7 @@ cdef extern from "<legate_dataframe/binaryop.hpp>" nogil:
         const cpp_LogicalColumn& rhs,
         string op,
         shared_ptr[CDataType] output_type
-    )
+    ) except +
 
 
 @_track_provenance

--- a/python/legate_dataframe/lib/copying.pyi
+++ b/python/legate_dataframe/lib/copying.pyi
@@ -1,0 +1,11 @@
+# Copyright (c) 2023-2024: int NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from legate_dataframe.lib.core.column import LogicalColumn
+from legate_dataframe.lib.core.scalar import ScalarLike
+
+def copy_if_else(
+    cond: LogicalColumn,
+    lhs: LogicalColumn | ScalarLike,
+    rhs: LogicalColumn | ScalarLike,
+) -> LogicalColumn: ...

--- a/python/legate_dataframe/lib/copying.pyx
+++ b/python/legate_dataframe/lib/copying.pyx
@@ -1,0 +1,67 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# distutils: language = c++
+# cython: language_level=3
+
+from legate_dataframe.lib.core.column cimport LogicalColumn, cpp_LogicalColumn
+from legate_dataframe.lib.core.scalar cimport cpp_scalar_col_from_python
+
+from legate_dataframe.utils import _track_provenance
+
+
+cdef extern from "<legate_dataframe/copying.hpp>" nogil:
+    cpp_LogicalColumn cpp_copy_if_else "copy_if_else"(
+        const cpp_LogicalColumn& lhs,
+        const cpp_LogicalColumn& rhs,
+        const cpp_LogicalColumn& cond,
+    ) except +
+
+
+@_track_provenance
+def copy_if_else(
+    LogicalColumn cond,
+    lhs: LogicalColumn | ScalarLike,
+    rhs: LogicalColumn | ScalarLike,
+) -> LogicalColumn:
+    """Performs a ternary if/else operation along the columns.
+
+    The result will contain the values of `lhs[i] if cond[i] else rhs[i]`.
+    Both ``lhs`` and ``rhs`` may be scalar columns in which case they are broadcast
+    against `cond`. `lhs` and `rhs` must have the same type.
+
+    Parameters
+    ----------
+    cond
+        Boolean column deciding which column each result element is taken from.
+    lhs
+        The left operand
+    lhs
+        The right operand
+
+    Returns
+    -------
+        Output column containing the result of the ternary if/else operation
+
+    Raises
+    ------
+    ValueError
+        If `lhs` and `rhs` do not have the same type or `cond` is not boolean.
+
+    """
+    cdef LogicalColumn lhs_col
+    cdef LogicalColumn rhs_col
+    # If an input is not a column, assume it is scalar:
+    if isinstance(lhs, LogicalColumn):
+        lhs_col = <LogicalColumn>lhs
+    else:
+        lhs_col = cpp_scalar_col_from_python(lhs)
+
+    if isinstance(rhs, LogicalColumn):
+        rhs_col = <LogicalColumn>rhs
+    else:
+        rhs_col = cpp_scalar_col_from_python(rhs)
+
+    return LogicalColumn.from_handle(
+        cpp_copy_if_else(cond._handle, lhs_col._handle, rhs_col._handle)
+    )

--- a/python/tests/test_copying.py
+++ b/python/tests/test_copying.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2023-2025, NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from legate_dataframe import LogicalColumn
+from legate_dataframe.lib.copying import copy_if_else
+from legate_dataframe.testing import (
+    assert_matches_polars,
+    gen_random_series,
+    get_pyarrow_column_set,
+)
+
+
+@pytest.mark.parametrize(
+    "array", get_pyarrow_column_set(["int32", "float32", "int64", "bool"])
+)
+def test_copy_if_else(array):
+    cond = pa.array(np.random.randint(0, 2, size=len(array)).astype(np.bool_))
+    cond_lg = LogicalColumn.from_arrow(cond)
+    lhs = LogicalColumn.from_arrow(array)
+    rhs = LogicalColumn.from_arrow(array[::-1])  # reverse to make it interesting!
+
+    res = copy_if_else(cond_lg, lhs, rhs)
+
+    expect = pa.compute.if_else(cond, array, array[::-1])
+    assert expect == res.to_arrow()
+
+
+def test_copy_if_else_string():
+    array = pa.array(["a", "b", "c", "this is a longer string!"])
+    cond = pa.array([False, True, True, False])
+    cond_lg = LogicalColumn.from_arrow(cond)
+    lhs = LogicalColumn.from_arrow(array)
+    rhs = LogicalColumn.from_arrow(array[::-1])  # reverse to make it interesting!
+
+    res = copy_if_else(cond_lg, lhs, rhs)
+
+    expect = pa.compute.if_else(cond, array, array[::-1])
+    assert expect == res.to_arrow()
+
+
+@pytest.mark.parametrize(
+    "lhs,rhs,cond",
+    [
+        (pa.array([1, 2, 3]), pa.scalar(42), pa.array([True, False, True])),
+        (pa.scalar(42), pa.array([1, 2, 3]), pa.array([True, False, True])),
+        (pa.scalar(42), pa.scalar(1), pa.array([True, False, True])),
+        (pa.scalar(42), pa.scalar(1), pa.scalar(True)),
+    ],
+)
+def test_copy_if_else_scalar(lhs, rhs, cond):
+    lhs_lg = LogicalColumn.from_arrow(lhs)
+    rhs_lg = LogicalColumn.from_arrow(rhs)
+    cond_lg = LogicalColumn.from_arrow(cond)
+
+    res = copy_if_else(cond_lg, lhs_lg, rhs_lg)
+    expect = pa.compute.if_else(cond, lhs, rhs)
+
+    if lhs_lg.is_scalar() and rhs_lg.is_scalar() and cond_lg.is_scalar():
+        assert res.is_scalar()
+        assert res.to_arrow() == pa.array([expect])
+    else:
+        assert not res.is_scalar()
+        assert res.to_arrow() == expect
+
+
+def test_copy_if_else_errors():
+    col1 = LogicalColumn.from_arrow(pa.array([1, 2, 3]))
+    col2 = LogicalColumn.from_arrow(pa.array([1.0, 2.0, 3.0]))
+    cond = LogicalColumn.from_arrow(pa.array([True, False, True]))
+    with pytest.raises(ValueError):
+        copy_if_else(cond, col1, col2)  # different type for col1 and col2
+
+    with pytest.raises(ValueError):
+        copy_if_else(col1, col1, col1)  # cond is not a boolean column
+
+
+def test_polars_ternary_copy_if_else():
+    pl = pytest.importorskip("polars")
+
+    a = gen_random_series(nelem=1000, num_nans=10)
+    b = gen_random_series(nelem=1000, num_nans=10)
+    c = pa.array(np.random.randint(0, 2, size=1000).astype(np.bool_))
+
+    a_s = pl.from_arrow(a)
+    b_s = pl.from_arrow(b)
+    c_s = pl.from_arrow(c)
+
+    q = pl.LazyFrame({"a": a_s, "b": b_s, "c": c_s}).with_columns(
+        result=pl.when("c").then(pl.col("a")).otherwise(pl.col("b"))
+    )
+    assert_matches_polars(q)
+
+    # Also check with at least one scalar involved:
+    q = pl.LazyFrame({"a": a_s, "b": b_s, "c": c_s}).with_columns(
+        result=pl.when("c").then(pl.col("a")).otherwise(42)
+    )
+    assert_matches_polars(q)

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -44,7 +44,7 @@ def test_python_launched_tasks():
 
     # Then, we can create the task and provide the task arguments using the
     # exact same order as in the task implementation ("unaryop.cpp").
-    task = runtime.create_auto_task(lib, 9)
+    task = runtime.create_auto_task(lib, 10)
     task.add_scalar_arg("abs", dtype=lg_type.string_type)
     col.add_as_next_task_input(task)
     result = LogicalColumn.empty_like_logical_column(col)


### PR DESCRIPTION
This adds the ternary copy_if_else operation functionality. I put it into `copying.cpp`, etc. since most of our structure matches libcudf right now (and that's where it is there).

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [x] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
