### PR TITLE
Allow groupby count-valid with and without nulls and expose to polars

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -75,8 +75,7 @@ rapids_cpm_init()
 
 # If CCCL versions don't get picked up correctly, we may need to add them early on here (right now
 # it seems fetching rmm/cudf manage to ensure we ge the right one.)
-include("${rapids-cmake-dir}/cpm/cccl.cmake")
-rapids_cpm_cccl()
+# include("${rapids-cmake-dir}/cpm/cccl.cmake") rapids_cpm_cccl()
 
 include(cmake/thirdparty/get_rmm.cmake)
 include(cmake/thirdparty/get_cudf.cmake)

--- a/cpp/include/legate_dataframe/groupby_aggregation.hpp
+++ b/cpp/include/legate_dataframe/groupby_aggregation.hpp
@@ -19,6 +19,8 @@
 #include <string>
 #include <vector>
 
+#include <arrow/compute/api.h>
+
 #include <legate_dataframe/core/library.hpp>
 #include <legate_dataframe/core/table.hpp>
 
@@ -44,17 +46,23 @@ class GroupByAggregationTask : public Task<GroupByAggregationTask, OpCode::Group
  * @param keys The names of the columns whose rows act as the groupby keys.
  * @param column_aggregations A vector of column aggregations to perform. Each column aggregation
  * produces a column in the output table by performing an aggregation-kind on a column in `table`.
- * It consist of a tuple: `(<input-column-name>, <aggregation-kind>, <output-column-name>)`. E.g.
- * `("x", "sum", "sum-of-x")` will produce a column named "sum-of-x" in the output table, which, for
- * each groupby key, has a row that contains the sum of the values in the column "x". Multiple
- * column aggregations can share the same input column but all output columns must be unique and not
- * conflict with the name of the key columns.
+ * It consist of a tuple: `(<input-column-name>, <aggregation-kind>, FunctionOptions,
+ * <output-column-name>)`. E.g. `("x", "sum", std::nullopt, "sum-of-x")` will produce a column named
+ * "sum-of-x" in the output table, which, for each groupby key, has a row that contains the sum of
+ * the values in the column "x". Multiple column aggregations can share the same input column but
+ * all output columns must be unique and not conflict with the name of the key columns. The options
+ * are `arrow::compute::FunctionsOptions` this allows mainly to include NULLs for "count_distinct"
+ * via the `CountOptions`.
+ *
  * @return A new logical table that contains the key columns and the aggregated columns using the
  * output column names and order specified in `column_aggregations`.
  */
 LogicalTable groupby_aggregation(
   const LogicalTable& table,
   const std::vector<std::string>& keys,
-  const std::vector<std::tuple<std::string, std::string, std::string>>& column_aggregations);
+  const std::vector<std::tuple<std::string,
+                               std::string,
+                               std::optional<std::shared_ptr<arrow::compute::FunctionOptions>>,
+                               std::string>>& column_aggregations);
 
 }  // namespace legate::dataframe

--- a/cpp/src/groupby_aggregation.cpp
+++ b/cpp/src/groupby_aggregation.cpp
@@ -50,13 +50,21 @@ std::string arrow_aggregation_name(std::string name)
   std::vector<arrow::compute::Aggregate> aggregates;
   auto column_aggs_size = argument::get_next_scalar<size_t>(ctx);
   for (size_t i = 0; i < column_aggs_size; ++i) {
-    auto in_col_idx  = argument::get_next_scalar<size_t>(ctx);
-    auto kind        = argument::get_next_scalar<std::string>(ctx);
+    auto in_col_idx = argument::get_next_scalar<size_t>(ctx);
+    auto kind       = argument::get_next_scalar<std::string>(ctx);
+    auto options =
+      argument::get_next_scalar<std::optional<std::shared_ptr<arrow::compute::FunctionOptions>>>(
+        ctx);
     auto out_col_idx = argument::get_next_scalar<size_t>(ctx);
     auto name        = arrow_aggregation_name(kind);
     if (name == "hash_count_all") {
+      if (options.has_value()) {
+        throw std::invalid_argument("count_all does not support options");
+      }
       assert(in_col_idx == key_col_idx[0]);
       aggregates.push_back({name, std::to_string(i)});
+    } else if (options.has_value()) {
+      aggregates.push_back({name, options.value(), std::to_string(in_col_idx), std::to_string(i)});
     } else {
       aggregates.push_back({name, std::to_string(in_col_idx), std::to_string(i)});
     }
@@ -88,9 +96,12 @@ std::string arrow_aggregation_name(std::string name)
 
 namespace {
 
-LogicalColumn make_output_column(const LogicalColumn& values, std::string aggregation_kind)
+LogicalColumn make_output_column(
+  const LogicalColumn& values,
+  const std::optional<std::shared_ptr<arrow::compute::FunctionOptions>>& options,
+  std::string aggregation_kind)
 {
-  if (aggregation_kind == "count_all") {
+  if (aggregation_kind == "count_all" || aggregation_kind == "count_distinct") {
     return LogicalColumn::empty_like(arrow::int64(), /* nullable = */ false);
   }
 
@@ -100,13 +111,18 @@ LogicalColumn make_output_column(const LogicalColumn& values, std::string aggreg
                                   {ARROW_RESULT(arrow::MakeEmptyArray(arrow::int32())),
                                    ARROW_RESULT(arrow::MakeEmptyArray(values.arrow_type()))});
 
+  arrow::compute::Aggregate agg;
+  if (options.has_value()) {
+    agg = arrow::compute::Aggregate(
+      task::arrow_aggregation_name(aggregation_kind), options.value(), "values", "result");
+  } else {
+    agg =
+      arrow::compute::Aggregate(task::arrow_aggregation_name(aggregation_kind), "values", "result");
+  }
+
   arrow::acero::Declaration plan = arrow::acero::Declaration::Sequence(
     {{"table_source", arrow::acero::TableSourceNodeOptions(table)},
-     {"aggregate",
-      arrow::acero::AggregateNodeOptions(
-        {arrow::compute::Aggregate(
-          task::arrow_aggregation_name(aggregation_kind), {"values"}, "result")},
-        {"keys", "values"})}});
+     {"aggregate", arrow::acero::AggregateNodeOptions({agg}, {"keys", "values"})}});
   auto result = ARROW_RESULT(arrow::acero::DeclarationToTable(std::move(plan)));
   // Note: Left nullable here as true - not sure there is a way to know in advance if it should
   // be nullable or not. The safe option is to set it true always.
@@ -117,12 +133,31 @@ LogicalColumn make_output_column(const LogicalColumn& values, std::string aggreg
 LogicalTable groupby_aggregation(
   const LogicalTable& table,
   const std::vector<std::string>& keys,
-  const std::vector<std::tuple<std::string, std::string, std::string>>&  // input column name,
-                                                                         // aggregation kind, output
-                                                                         // column name
-    column_aggregations)
+  // input column name, aggregation kind, aggregation options (may be nullptr), result column name
+  const std::vector<std::tuple<std::string,
+                               std::string,
+                               std::optional<std::shared_ptr<arrow::compute::FunctionOptions>>,
+                               std::string>>& column_aggregations)
 {
   if (keys.size() == 0) { throw std::invalid_argument("must pass at least one key column"); }
+
+  for (const auto& [in_col_name, kind, options, out_col_name] : column_aggregations) {
+    // Check that the options are valid for the given function/kind.
+    auto registry = arrow::compute::GetFunctionRegistry();
+    auto func     = ARROW_RESULT(registry->GetFunction(kind));
+    if (!func) { throw std::invalid_argument("unknown aggregation function: " + kind); }
+    if (options.has_value()) {
+      std::string options_type          = options.value()->type_name();
+      std::string expected_options_type = func->doc().options_class;
+      if (expected_options_type != options_type) {
+        throw std::invalid_argument("options type '" + std::string(options_type) +
+                                    "' does not match expected type '" + expected_options_type +
+                                    "' for function '" + kind + "'");
+      }
+    } else if (func->doc().options_required) {
+      throw std::invalid_argument("options are required for function '" + kind + "'");
+    }
+  }
 
   // Let's create the output table
   std::vector<LogicalColumn> output_columns;
@@ -133,10 +168,10 @@ LogicalTable groupby_aggregation(
     output_column_names.push_back(std::move(key));
   }
   // And then it has one column per column aggregation
-  for (const auto& [in_col_name, kind, out_col_name] : column_aggregations) {
+  for (const auto& [in_col_name, kind, options, out_col_name] : column_aggregations) {
     // Use the provided column, or the first key for count_all:
     auto col = (kind != "count_all") ? table.get_column(in_col_name) : table.get_column(keys[0]);
-    output_columns.push_back(make_output_column(col, kind));
+    output_columns.push_back(make_output_column(col, options, kind));
 
     if (std::find(output_column_names.begin(), output_column_names.end(), out_col_name) !=
         output_column_names.end()) {
@@ -153,8 +188,12 @@ LogicalTable groupby_aggregation(
   }
 
   // Since `PhysicalTable` doesn't have column names, we convert names to indices
-  std::vector<std::tuple<size_t, std::string, size_t>> column_aggs;
-  for (const auto& [in_col_name, kind, out_col_name] : column_aggregations) {
+  std::vector<std::tuple<size_t,
+                         std::string,
+                         std::optional<std::shared_ptr<arrow::compute::FunctionOptions>>,
+                         size_t>>
+    column_aggs;
+  for (const auto& [in_col_name, kind, options, out_col_name] : column_aggregations) {
     if (kind == "count_all" && in_col_name != "") {
       throw std::invalid_argument("count_all must use the empty string as column name.");
     }
@@ -163,7 +202,7 @@ LogicalTable groupby_aggregation(
 
     // We index the output columns after the key columns
     size_t out_col_idx = keys.size() + column_aggs.size();
-    column_aggs.push_back(std::make_tuple(in_col_idx, kind, out_col_idx));
+    column_aggs.push_back(std::make_tuple(in_col_idx, kind, options, out_col_idx));
   }
 
   auto runtime = legate::Runtime::get_runtime();
@@ -174,9 +213,10 @@ LogicalTable groupby_aggregation(
   argument::add_next_scalar_vector(task, key_col_idx);
   // Add the `column_aggs` task argument
   argument::add_next_scalar(task, column_aggs.size());
-  for (const auto& [in_col_idx, kind, out_col_idx] : column_aggs) {
+  for (const auto& [in_col_idx, kind, options, out_col_idx] : column_aggs) {
     argument::add_next_scalar(task, in_col_idx);
     argument::add_next_scalar(task, kind);
+    argument::add_next_scalar(task, options);
     argument::add_next_scalar(task, out_col_idx);
   }
 

--- a/cpp/tests/test_groupby_aggregation.cpp
+++ b/cpp/tests/test_groupby_aggregation.cpp
@@ -92,7 +92,8 @@ TYPED_TEST(GroupByAggregationTest, single_sum_with_nulls)
      {"aggregate", arrow::acero::AggregateNodeOptions({aggregate}, {"key"})}});
   auto expected = ARROW_RESULT(arrow::acero::DeclarationToTable(std::move(plan)));
 
-  auto result = groupby_aggregation(table, {"key"}, {std::make_tuple("value", "sum", "sum")});
+  auto result =
+    groupby_aggregation(table, {"key"}, {std::make_tuple("value", "sum", std::nullopt, "sum")});
 
   result = legate::dataframe::sort(result, {"key"}, {true}, true, true);
 
@@ -113,9 +114,11 @@ TYPED_TEST(GroupByAggregationTest, nunique_and_max)
   auto table = LogicalTable({keys_column, vals1_column, vals2_column}, names);
 
   // Create expected result using Arrow
+  auto count_opts =
+    std::make_shared<arrow::compute::CountOptions>(arrow::compute::CountOptions::CountMode::ALL);
   arrow::compute::Aggregate nunique_agg1("hash_count_distinct", {"vals1"}, "nunique1");
   arrow::compute::Aggregate max_agg1("hash_max", {"vals1"}, "max1");
-  arrow::compute::Aggregate nunique_agg2("hash_count_distinct", {"vals2"}, "nunique2");
+  arrow::compute::Aggregate nunique_agg2("hash_count_distinct", count_opts, "vals2", "nunique2");
   arrow::compute::Aggregate max_agg2("hash_max", {"vals2"}, "max2");
 
   arrow::acero::Declaration plan = arrow::acero::Declaration::Sequence(
@@ -125,12 +128,13 @@ TYPED_TEST(GroupByAggregationTest, nunique_and_max)
                                          {"key"})}});
   auto expected = ARROW_RESULT(arrow::acero::DeclarationToTable(std::move(plan)));
 
-  auto result = groupby_aggregation(table,
-                                    {"key"},
-                                    {std::make_tuple("vals1", "count_distinct", "nunique1"),
-                                     std::make_tuple("vals1", "max", "max1"),
-                                     std::make_tuple("vals2", "count_distinct", "nunique2"),
-                                     std::make_tuple("vals2", "max", "max2")});
+  auto result =
+    groupby_aggregation(table,
+                        {"key"},
+                        {std::make_tuple("vals1", "count_distinct", std::nullopt, "nunique1"),
+                         std::make_tuple("vals1", "max", std::nullopt, "max1"),
+                         std::make_tuple("vals2", "count_distinct", count_opts, "nunique2"),
+                         std::make_tuple("vals2", "max", std::nullopt, "max2")});
 
   result = legate::dataframe::sort(result, {"key"}, {true}, true, true);
 
@@ -161,10 +165,10 @@ TYPED_TEST(GroupByAggregationTest, stddev_and_mean_with_multiple_keys)
 
   auto result = groupby_aggregation(table,
                                     {"keys1", "keys2"},
-                                    {std::make_tuple("vals1", "stddev", "stddev1"),
-                                     std::make_tuple("vals1", "mean", "mean1"),
-                                     std::make_tuple("vals2", "stddev", "stddev2"),
-                                     std::make_tuple("vals2", "mean", "mean2")});
+                                    {std::make_tuple("vals1", "stddev", std::nullopt, "stddev1"),
+                                     std::make_tuple("vals1", "mean", std::nullopt, "mean1"),
+                                     std::make_tuple("vals2", "stddev", std::nullopt, "stddev2"),
+                                     std::make_tuple("vals2", "mean", std::nullopt, "mean2")});
 
   result = legate::dataframe::sort(result, {"keys1", "keys2"}, {true, true}, true, true);
 

--- a/python/legate_dataframe/lib/groupby_aggregation.pyi
+++ b/python/legate_dataframe/lib/groupby_aggregation.pyi
@@ -3,10 +3,14 @@
 
 from typing import Iterable, Tuple
 
+from pyarrow.compute import FunctionOptions
+
 from legate_dataframe.lib.core.table import LogicalTable
 
 def groupby_aggregation(
     table: LogicalTable,
     keys: Iterable[str],
-    column_aggregations: Iterable[Tuple[str | None, str, str]],
+    column_aggregations: Iterable[
+        Tuple[str | None, str | Tuple[str, FunctionOptions], str]
+    ],
 ) -> LogicalTable: ...


### PR DESCRIPTION
This channels through the FunctionOptions from arrow all the way into the task, the nice thing is that those come already with serialization capabilities.

The only thing really supported right now (on the GPU) is for counting NULLs or not.  We could support more in the future.

We might add more options in the future (but maybe also disable CPU ones if they are not amendable to improving the distributed algorithm).

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [x] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
