### PR TITLE
BUG: Fix is-partitioned check for string columns in joins

### DIFF
--- a/cpp/include/legate_dataframe/core/column.hpp
+++ b/cpp/include/legate_dataframe/core/column.hpp
@@ -611,7 +611,11 @@ class PhysicalColumn {
    *
    * @return true if data is partitioned.
    */
-  [[nodiscard]] bool is_partitioned() const { return array_.data().is_partitioned(); }
+  [[nodiscard]] bool is_partitioned() const
+  {
+    if (!array_.nested()) { return array_.data().is_partitioned(); }
+    return array_.as_string_array().ranges().data().is_partitioned();
+  }
 
   /**
    * @brief Return a cudf column view of this physical column

--- a/python/tests/test_join.py
+++ b/python/tests/test_join.py
@@ -141,9 +141,14 @@ def test_join(
     assert_arrow_table_equal(res.sort_by(sort_order), expect.sort_by(sort_order))
 
 
-def test_column_names():
-    lhs = LogicalTable.from_arrow(pa.table({"key": [1, 2, 3], "data0": [1, 2, 3]}))
-    rhs = LogicalTable.from_arrow(pa.table({"key": [3, 2, 1], "data1": [1, 2, 3]}))
+def test_column_names_and_strings():
+    # Also use string as keys
+    lhs = LogicalTable.from_arrow(
+        pa.table({"key": ["1", "2", "3"], "data0": [1, 2, 3]})
+    )
+    rhs = LogicalTable.from_arrow(
+        pa.table({"key": ["3", "2", "1"], "data1": ["1", "2", "3"]})
+    )
 
     res = join(
         lhs,


### PR DESCRIPTION
Apparently, string joins got broken at some point and we didn't notice. Modifies one tests to have a minimal check for string columns, which should have caught this.
