### PR TITLE
BUG: Fix upcast of int sums

### DIFF
--- a/python/legate_dataframe/ldf_polars/utils/aggregations.py
+++ b/python/legate_dataframe/ldf_polars/utils/aggregations.py
@@ -9,7 +9,6 @@ import itertools
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
-import polars as pl
 import pylibcudf as plc
 
 from legate_dataframe.ldf_polars.dsl import expr, ir
@@ -134,7 +133,7 @@ def decompose_single_agg(
             )
         elif agg.name == "sum":
             col = (
-                expr.Cast(agg.dtype, expr.Col(pl.datatypes.Int64(), name))
+                expr.Cast(agg.dtype, expr.Col(plc.DataType(plc.TypeId.INT64), name))
                 if (
                     plc.traits.is_integral(agg.dtype)
                     and agg.dtype.id() != plc.TypeId.INT64

--- a/python/tests/test_groupby_aggregation.py
+++ b/python/tests/test_groupby_aggregation.py
@@ -182,14 +182,15 @@ def test_numeric_aggregations(value_type, key_type, aggregation):
         # "tdigest",
     ],
 )
-def test_polars_basic(agg):
+@pytest.mark.parametrize("dtype", ["float64", "int32", "int64"])
+def test_polars_basic(agg, dtype):
     pl = pytest.importorskip("polars")
 
     mask = np.random.randint(2, size=10_000, dtype=bool)
     q = pl.DataFrame(
         {
             "a": pa.array(np.random.random(10_000), mask=mask),
-            "b": np.random.randint(100, size=10_000),
+            "b": np.random.randint(100, size=10_000).astype(dtype),
         }
     ).lazy()
 


### PR DESCRIPTION
In the polars path, the wrong dtype object was used meaning that this just errored out.
The test is now parametrized to catch this.
