### PR TITLE
ENH: Add semi and anti joins

### DIFF
--- a/cpp/include/legate_dataframe/join.hpp
+++ b/cpp/include/legate_dataframe/join.hpp
@@ -22,7 +22,7 @@
 #include <legate_dataframe/core/table.hpp>
 
 namespace legate::dataframe {
-enum class JoinType : int32_t { INNER = 0, LEFT, FULL };
+enum class JoinType : int32_t { INNER = 0, LEFT, FULL, SEMI, ANTI };
 enum class BroadcastInput : int32_t { AUTO = 0, LEFT, RIGHT };
 
 namespace task {

--- a/cpp/src/join.cpp
+++ b/cpp/src/join.cpp
@@ -484,10 +484,13 @@ LogicalTable join(const LogicalTable& lhs,
                   bool nulls_equal,
                   BroadcastInput broadcast)
 {
-  // By default, the output includes all the columns from `lhs` and `rhs`.
+  // By default, the output includes all the columns from `lhs`.
   std::vector<size_t> lhs_out_columns(lhs.num_columns());
   std::iota(lhs_out_columns.begin(), lhs_out_columns.end(), 0);
-  std::vector<size_t> rhs_out_columns(rhs.num_columns());
+  // Include all `rhs` columns, but SEMI or ANTI never does (or can).
+  auto rhs_cols =
+    (join_type == JoinType::SEMI || join_type == JoinType::ANTI) ? 0 : rhs.num_columns();
+  std::vector<size_t> rhs_out_columns(rhs_cols);
   std::iota(rhs_out_columns.begin(), rhs_out_columns.end(), 0);
   return join(lhs,
               rhs,

--- a/cpp/tests/test_join.cpp
+++ b/cpp/tests/test_join.cpp
@@ -243,7 +243,7 @@ TEST(JoinTest, LeftJoinNoNulls)
   test_join(table_0, table_1, {0, 1}, {0, 1}, legate::dataframe::JoinType::LEFT);
 }
 
-TEST(JoinTest, LeftJoinWithNulls)
+TEST(JoinTest, LeftAntiSemiJoinWithNulls)
 {
   LogicalColumn a(std::vector<int32_t>{3, 1, 2, 0, 2});
   LogicalColumn b(make_string_array_with_nulls({"s1", "s1", "", "s4", "s0"}, {1, 1, 0, 1, 1}));
@@ -256,6 +256,8 @@ TEST(JoinTest, LeftJoinWithNulls)
   LogicalTable table_1({d, e, f}, {"d", "e", "f"});
 
   test_join(table_0, table_1, {0, 1}, {0, 1}, legate::dataframe::JoinType::LEFT);
+  test_join(table_0, table_1, {0, 1}, {0, 1}, legate::dataframe::JoinType::ANTI);
+  test_join(table_0, table_1, {0, 1}, {0, 1}, legate::dataframe::JoinType::SEMI);
 }
 
 TEST(JoinTest, LeftJoinOnNulls)

--- a/cpp/tests/test_join.cpp
+++ b/cpp/tests/test_join.cpp
@@ -81,6 +81,12 @@ std::shared_ptr<arrow::Table> arrow_join(const legate::dataframe::LogicalTable& 
     case legate::dataframe::JoinType::FULL:
       arrow_join_type = arrow::acero::JoinType::FULL_OUTER;
       break;
+    case legate::dataframe::JoinType::SEMI:
+      arrow_join_type = arrow::acero::JoinType::LEFT_SEMI;
+      break;
+    case legate::dataframe::JoinType::ANTI:
+      arrow_join_type = arrow::acero::JoinType::LEFT_ANTI;
+      break;
     default: throw std::invalid_argument("Unsupported join type");
   }
 

--- a/python/legate_dataframe/ldf_polars/dsl/ir.py
+++ b/python/legate_dataframe/ldf_polars/dsl/ir.py
@@ -1075,6 +1075,10 @@ class Join(IR):
             join_type = join.JoinType.LEFT
         elif how == "Full":
             join_type = join.JoinType.FULL
+        elif how == "Semi":
+            join_type = join.JoinType.SEMI
+        elif how == "Anti":
+            join_type = join.JoinType.ANTI
         else:
             raise NotImplementedError(f"{how=}")
 
@@ -1092,9 +1096,12 @@ class Join(IR):
 
         # Now, drop the join column if coalesce is given
         assert coalesce is not None
-        if coalesce:
-            for name in right_on:
-                rhs_out_columns.remove(name)
+        if join_type in {join.JoinType.SEMI, join.JoinType.ANTI}:
+            rhs_out_columns = []
+        else:
+            if coalesce:
+                for name in right_on:
+                    rhs_out_columns.remove(name)
 
         df = join.join(
             left_tbl,

--- a/python/legate_dataframe/lib/join.pyi
+++ b/python/legate_dataframe/lib/join.pyi
@@ -10,6 +10,8 @@ class JoinType(Enum):
     INNER: int
     LEFT: int
     FULL: int
+    SEMI: int
+    ANTI: int
 
 class BroadcastInput(Enum):
     AUTO: int

--- a/python/legate_dataframe/lib/join.pyx
+++ b/python/legate_dataframe/lib/join.pyx
@@ -20,11 +20,14 @@ from legate_dataframe.utils import _track_provenance
 
 cdef extern from "<legate_dataframe/join.hpp>" namespace "legate::dataframe":
     cpdef enum class JoinType(int32_t):
-        """Options for the join type (``INNER``, ``LEFT``, ``FULL``).
+        """Options for the join type (``INNER``, ``LEFT``, ``FULL``, ``SEMI``,
+        ``ANTI``).
         """
         INNER,
         LEFT,
-        FULL
+        FULL,
+        SEMI,
+        ANTI
 
     cpdef enum class BroadcastInput(int32_t):
         """Options for input broadcasting (``AUTO``, ``LEFT``, and ``RIGHT``).
@@ -109,7 +112,10 @@ def join(
     if lhs_out_columns is None:
         lhs_out_columns = lhs.get_column_names()
     if rhs_out_columns is None:
-        rhs_out_columns = rhs.get_column_names()
+        if join_type == JoinType.ANTI or join_type == JoinType.SEMI:
+            rhs_out_columns = []  # cannot select any columns with these joins
+        else:
+            rhs_out_columns = rhs.get_column_names()
 
     cdef vector[string] lhs_key_vector
     cdef vector[string] rhs_key_vector

--- a/python/tests/test_join.py
+++ b/python/tests/test_join.py
@@ -73,6 +73,8 @@ def make_param():
         JoinType.INNER,
         JoinType.LEFT,
         JoinType.FULL,
+        JoinType.SEMI,
+        JoinType.ANTI,
     ),
 )
 @pytest.mark.parametrize(
@@ -97,7 +99,10 @@ def test_join(
     lg_rhs = LogicalTable.from_arrow(arrow_rhs)
 
     if (how == JoinType.FULL and broadcast != BroadcastInput.AUTO) or (
-        how == JoinType.LEFT and broadcast == BroadcastInput.LEFT
+        (
+            how in {JoinType.LEFT, JoinType.SEMI, JoinType.ANTI}
+            and broadcast == BroadcastInput.LEFT
+        )
     ):
         # In these cases we don't support broadcasting (at least for now)
         with pytest.raises(RuntimeError):
@@ -116,6 +121,8 @@ def test_join(
         JoinType.INNER: "inner",
         JoinType.LEFT: "left",
         JoinType.FULL: "full",
+        JoinType.SEMI: "semi",
+        JoinType.ANTI: "anti",
     }
 
     expect = (
@@ -213,6 +220,8 @@ def test_empty_chunks(threshold):
         "inner",
         "left",
         "full",
+        "semi",
+        "anti",
     ),
 )
 @pytest.mark.parametrize("arrow_lhs,arrow_rhs,left_on,right_on", make_param())


### PR DESCRIPTION
These are slightly different, mainly since the rhs is just used for filtering so they never return columns.  Otherwise they are straight forward, though.
(Conditional joins support for polars is trickier, we could probably create a basic working version easily via pre-processing but lowering conditional logic to both libcudf and arrow could get annoying.)

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [x] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [x] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
