### PR TITLE
Enable polars groupby min/max by adding minimal mask_nans functionality

### DIFF
--- a/python/legate_dataframe/ldf_polars/dsl/expressions/unary.py
+++ b/python/legate_dataframe/ldf_polars/dsl/expressions/unary.py
@@ -160,7 +160,10 @@ class UnaryFunction(Expr):
         # - cum_max
         # - cum_prod
         # - cum_sum
-        if self.name == "round":
+        if self.name == "mask_nans":
+            column = self.children[0].evaluate(df, context=context)
+            return column.mask_nans()
+        elif self.name == "round":
             round_mode = "half_away_from_zero"
             if POLARS_VERSION_LT_129:
                 (decimal_places,) = self.options  # pragma: no cover

--- a/python/tests/test_groupby_aggregation.py
+++ b/python/tests/test_groupby_aggregation.py
@@ -17,6 +17,7 @@ from typing import Iterable, List, Tuple
 
 import numpy as np
 import pyarrow as pa
+import pyarrow.compute
 import pytest
 
 from legate_dataframe import LogicalTable
@@ -165,9 +166,8 @@ def test_numeric_aggregations(value_type, key_type, aggregation):
     [
         "sum",
         # "product",
-        # TODO: min/max require mask_nan's.
-        # "min",
-        # "max",
+        "min",
+        "max",
         "mean",
         "count",
         "len",  # -> "count_all"


### PR DESCRIPTION
This should be a bit nicer and it could be soon, but I also doubt that it is speed relevant.
(I.e. the nice thing would be to just create a new mask, but that requires the ability to create a new array that uses the old store easily which should be in legate pretty soon though.)