### PR TITLE
Add basic distinct (unique) capability

### DIFF
--- a/cpp/include/legate_dataframe/core/library.hpp
+++ b/cpp/include/legate_dataframe/core/library.hpp
@@ -35,6 +35,7 @@ enum : int {
   Copy,
   CopyOffsets,  // can apply an offset to ranges
   Contains,
+  Distinct,
   ParquetWrite,
   ParquetRead,
   ParquetReadByRows,

--- a/cpp/src/core/library.cpp
+++ b/cpp/src/core/library.cpp
@@ -97,6 +97,8 @@ class Mapper : public legate::mapping::Mapper {
           // Also similar to GroupBy, but does multiple shuffles and uses two
           // additional helper columns
           return std::nullopt;
+        case legate::dataframe::task::OpCode::Distinct:
+          // Identical to GroupByAggregation.
         case legate::dataframe::task::OpCode::GroupByAggregation: {
           // Aggregation use repartitioning which uses ZCMEM for NCCL.
           // This depends on the number of columns (first scalar when storing

--- a/cpp/src/stream_compaction.cpp
+++ b/cpp/src/stream_compaction.cpp
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
-#include <arrow/compute/api.h>
+#include <arrow/acero/api.h>
+#include <arrow/api.h>
 #include <legate.h>
+#include <legate_dataframe/core/repartition_by_hash.hpp>
 #include <legate_dataframe/core/task_argument.hpp>
 #include <legate_dataframe/core/task_context.hpp>
 #include <legate_dataframe/stream_compaction.hpp>
@@ -39,6 +41,60 @@ namespace task {
   output.move_into(std::move(result));
 }
 
+/*static*/ void DistinctTask::cpu_variant(legate::TaskContext context)
+{
+  TaskContext ctx{context};
+  auto table            = argument::get_next_input<PhysicalTable>(ctx);
+  auto output           = argument::get_next_output<PhysicalTable>(ctx);
+  auto key_col_idx      = argument::get_next_scalar_vector<int32_t>(ctx);
+  auto high_cardinality = argument::get_next_scalar<bool>(ctx);
+
+  auto working_table = table.arrow_table_view();
+
+  // Arrow has no explicit distinct, so we implement it via groupby/hash aggs.
+  // Columns that are not keys are aggregated via "hash_one" (pick random entry)
+  std::map<std::size_t, std::size_t> key_col_idx_map;
+  for (size_t i = 0; i < key_col_idx.size(); ++i) {
+    key_col_idx_map[key_col_idx[i]] = i;
+  }
+  std::vector<arrow::compute::Aggregate> aggregates;
+  // The result has agg columns last, so need to reorder before returning.
+  std::vector<int> res_col_order(working_table->num_columns());
+  for (size_t i = 0; i < working_table->num_columns(); ++i) {
+    if (key_col_idx_map.count(i) == 0) {
+      res_col_order[i] = key_col_idx.size() + aggregates.size();
+      aggregates.push_back({"hash_one", std::to_string(i), std::to_string(i)});
+    } else {
+      res_col_order[i] = key_col_idx_map.at(i);
+    }
+  }
+  std::vector<arrow::FieldRef> key_names;
+  for (auto idx : key_col_idx) {
+    key_names.push_back(std::to_string(idx));
+  }
+
+  if (!high_cardinality && table.is_partitioned()) {
+    arrow::acero::Declaration plan = arrow::acero::Declaration::Sequence(
+      {{"table_source", arrow::acero::TableSourceNodeOptions(working_table)},
+       {"aggregate", arrow::acero::AggregateNodeOptions(aggregates, key_names)}});
+    working_table =
+      ARROW_RESULT(arrow::acero::DeclarationToTable(std::move(plan), false /*use_threads*/));
+  }
+
+  // Repartition `table` based on the keys such that each node can do a local distinct.
+  working_table = repartition_by_hash(
+    ctx, working_table, std::vector<std::size_t>(key_col_idx.begin(), key_col_idx.end()));
+
+  arrow::acero::Declaration plan = arrow::acero::Declaration::Sequence(
+    {{"table_source", arrow::acero::TableSourceNodeOptions(working_table)},
+     {"aggregate", arrow::acero::AggregateNodeOptions(aggregates, key_names)}});
+  working_table =
+    ARROW_RESULT(arrow::acero::DeclarationToTable(std::move(plan), false /*use_threads*/));
+  working_table = ARROW_RESULT(working_table->SelectColumns(res_col_order));
+
+  output.move_into(std::move(working_table));
+}
+
 }  // namespace task
 
 LogicalTable apply_boolean_mask(const LogicalTable& tbl, const LogicalColumn& boolean_mask)
@@ -60,6 +116,36 @@ LogicalTable apply_boolean_mask(const LogicalTable& tbl, const LogicalColumn& bo
   runtime->submit(std::move(task));
   return ret;
 }
+
+LogicalTable distinct(const LogicalTable& tbl,
+                      const std::vector<std::string>& keys,
+                      bool high_cardinality)
+{
+  auto runtime = legate::Runtime::get_runtime();
+  auto ret     = LogicalTable::empty_like(tbl);
+
+  std::vector<int32_t> key_col_idx;
+  for (const std::string& key : keys) {
+    key_col_idx.push_back(tbl.get_column_names().at(key));
+  }
+
+  legate::AutoTask task =
+    runtime->create_task(get_library(), task::DistinctTask::TASK_CONFIG.task_id());
+
+  argument::add_next_input(task, tbl);
+  argument::add_next_output(task, ret);
+  argument::add_next_scalar_vector(task, key_col_idx);
+  argument::add_next_scalar(task, high_cardinality);
+
+  if (runtime->get_machine().count(legate::mapping::TaskTarget::GPU) == 0) {
+    task.add_communicator("cpu");
+  } else {
+    task.add_communicator("nccl");
+  }
+  runtime->submit(std::move(task));
+  return ret;
+}
+
 }  // namespace legate::dataframe
 
 namespace {
@@ -67,6 +153,7 @@ namespace {
 void __attribute__((constructor)) register_tasks()
 {
   legate::dataframe::task::ApplyBooleanMaskTask::register_variants();
+  legate::dataframe::task::DistinctTask::register_variants();
 }
 
 }  // namespace

--- a/cpp/src/stream_compaction.cu
+++ b/cpp/src/stream_compaction.cu
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-#include <cudf/types.hpp>
 #include <legate.h>
 
 #include <cudf/stream_compaction.hpp>
+#include <cudf/types.hpp>
+#include <legate_dataframe/core/repartition_by_hash.hpp>
 #include <legate_dataframe/core/task_argument.hpp>
 #include <legate_dataframe/core/task_context.hpp>
 #include <legate_dataframe/stream_compaction.hpp>
@@ -35,6 +36,42 @@ namespace legate::dataframe::task {
 
   auto ret =
     cudf::apply_boolean_mask(tbl.table_view(), boolean_mask.column_view(), ctx.stream(), ctx.mr());
+  output.move_into(std::move(ret));
+}
+
+/*static*/ void DistinctTask::gpu_variant(legate::TaskContext context)
+{
+  TaskContext ctx{context};
+  auto table            = argument::get_next_input<PhysicalTable>(ctx);
+  auto output           = argument::get_next_output<PhysicalTable>(ctx);
+  auto key_col_idx      = argument::get_next_scalar_vector<int32_t>(ctx);
+  auto high_cardinality = argument::get_next_scalar<bool>(ctx);
+
+  std::unique_ptr<cudf::table> working_table;
+  auto working_view = table.table_view();
+
+  if (!high_cardinality && table.is_partitioned()) {
+    // If the table has few unique entries, we can reduce work by
+    // calling distinct before repartitioning.
+    working_table = cudf::distinct(table.table_view(),
+                                   key_col_idx,
+                                   cudf::duplicate_keep_option::KEEP_ANY,
+                                   cudf::null_equality::EQUAL,
+                                   cudf::nan_equality::ALL_EQUAL,
+                                   ctx.stream(),
+                                   ctx.mr());
+    working_view  = working_table->view();
+  }
+  working_table = repartition_by_hash(ctx, working_view, key_col_idx);
+  working_view  = working_table->view();
+
+  auto ret = cudf::distinct(working_view,
+                            key_col_idx,
+                            cudf::duplicate_keep_option::KEEP_ANY,
+                            cudf::null_equality::EQUAL,
+                            cudf::nan_equality::ALL_EQUAL,
+                            ctx.stream(),
+                            ctx.mr());
   output.move_into(std::move(ret));
 }
 

--- a/cpp/tests/test_stream_compaction.cpp
+++ b/cpp/tests/test_stream_compaction.cpp
@@ -46,3 +46,24 @@ TEST(StreamCompactionTest, ApplyBooleanMask)
                .table();
   EXPECT_TRUE(result.get_arrow()->Equals(*expected));
 }
+
+TEST(StreamCompactionTest, Distinct)
+{
+  LogicalColumn col_0(std::vector<int32_t>{0, 0, 0, 1, 1, 1},
+                      {false, false, false, true, true, true});
+  LogicalColumn col_1(std::vector<std::string>{"this", "this", "string", "string", "col", "col"});
+  LogicalColumn col_2(std::vector<double>{0, 0, 2, 3, 4, 4});
+
+  LogicalTable tbl{{col_0, col_1, col_2}, {"a", "b", "c"}};
+
+  auto result = distinct(tbl, {"a", "b"});
+
+  // Hardcoded expected result (we have no simple arrow unique call).
+  LogicalColumn col_0_exp(std::vector<int32_t>{0, 0, 1, 1}, {false, false, true, true});
+  LogicalColumn col_1_exp(std::vector<std::string>{"this", "string", "string", "col"});
+  LogicalColumn col_2_exp(std::vector<double>{0, 2, 3, 4});
+  LogicalTable expected{{col_0_exp, col_1_exp, col_2_exp}, {"a", "b", "c"}};
+  auto expected_arrow = expected.get_arrow();
+
+  EXPECT_TRUE(result.get_arrow()->Equals(*expected_arrow));
+}

--- a/python/legate_dataframe/ldf_polars/dsl/translate.py
+++ b/python/legate_dataframe/ldf_polars/dsl/translate.py
@@ -363,7 +363,16 @@ def _(
 
 @_translate_ir.register
 def _(node: pl_ir.Distinct, translator: Translator, schema: Schema) -> ir.IR:
-    raise NotImplementedError("Distinct not supported")
+    (keep, subset, maintain_order, zlice) = node.options
+    subset = frozenset(subset) if subset is not None else None
+    return ir.Distinct(
+        schema,
+        keep,
+        subset,
+        zlice,
+        maintain_order,
+        translator.translate_ir(n=node.input),
+    )
 
 
 @_translate_ir.register

--- a/python/legate_dataframe/lib/stream_compaction.pyi
+++ b/python/legate_dataframe/lib/stream_compaction.pyi
@@ -1,10 +1,18 @@
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Iterable
+
 from legate_dataframe import LogicalColumn, LogicalTable
 
 __all__ = ["apply_boolean_mask"]
 
 def apply_boolean_mask(
     tbl: LogicalTable, boolean_mask: LogicalColumn
+) -> LogicalTable: ...
+def distinct(
+    tbl: LogicalTable,
+    keys: Iterable[str] | None = None,
+    *,
+    high_cardinality: bool = False,
 ) -> LogicalTable: ...

--- a/python/legate_dataframe/lib/stream_compaction.pyx
+++ b/python/legate_dataframe/lib/stream_compaction.pyx
@@ -4,6 +4,9 @@
 # distutils: language = c++
 # cython: language_level=3
 
+from libcpp cimport bool as cpp_bool
+from libcpp.string cimport string
+from libcpp.vector cimport vector
 
 from legate_dataframe.lib.core.column cimport LogicalColumn, cpp_LogicalColumn
 from legate_dataframe.lib.core.table cimport LogicalTable, cpp_LogicalTable
@@ -15,6 +18,11 @@ cdef extern from "<legate_dataframe/stream_compaction.hpp>" nogil:
     cpp_LogicalTable cpp_apply_boolean_mask "legate::dataframe::apply_boolean_mask"(
         const cpp_LogicalTable& tbl,
         const cpp_LogicalColumn& boolean_mask,
+    ) except +
+    cpp_LogicalTable cpp_distinct "legate::dataframe::distinct"(
+        const cpp_LogicalTable& tbl,
+        const vector[string] keys,
+        cpp_bool high_cardinality,
     ) except +
 
 
@@ -41,3 +49,43 @@ def apply_boolean_mask(
     """
     return LogicalTable.from_handle(
         cpp_apply_boolean_mask(tbl._handle, boolean_mask._handle))
+
+
+@_track_provenance
+def distinct(
+    LogicalTable tbl,
+    keys=None,
+    *,
+    high_cardinality=False,
+):
+    """Filter a table busing a boolean mask.
+
+    Select all rows from the table where the boolean mask column is true
+    (non-null and not false).  The operation is stable.
+
+    Parameters
+    ----------
+    tbl
+        The table to filter.
+    keys
+        Keys that must be distinct.  If not given, use all columns.
+    high_cardinality : bool
+        If set to ``True`` assume the result has high cardinality.
+        Otherwise (current default), assumes the result has low cardinality.
+        If the result has low cardinality (many duplicate rows) it is useful
+        to perform a local distinct to reduce communication. In the worst case
+        (all unique) this doubles the non-communication part of the work.
+
+    Returns
+    -------
+        The ``LogicalTable`` containing only distinct rows.
+    """
+    cdef vector[string] cpp_keys
+
+    if keys is None:
+        keys = tbl.get_column_names()  # all names
+    for key in keys:
+        cpp_keys.push_back(key.encode('UTF-8'))
+
+    return LogicalTable.from_handle(
+        cpp_distinct(tbl._handle, cpp_keys, high_cardinality))

--- a/python/tests/test_stream_compaction.py
+++ b/python/tests/test_stream_compaction.py
@@ -17,7 +17,7 @@ import pyarrow as pa
 import pytest
 
 from legate_dataframe import LogicalColumn, LogicalTable
-from legate_dataframe.lib.stream_compaction import apply_boolean_mask
+from legate_dataframe.lib.stream_compaction import apply_boolean_mask, distinct
 from legate_dataframe.testing import (
     assert_arrow_table_equal,
     assert_matches_polars,
@@ -77,6 +77,28 @@ def test_apply_boolean_mask_errors(bad_mask):
 
 
 @pytest.mark.parametrize(
+    "keys, high_cardinality",
+    [
+        (["b", "a"], True),
+        (["a", "b"], False),
+        (["b", "c"], False),
+        (None, False),
+    ],
+)
+def test_distinct_basic(keys, high_cardinality):
+    df = pa.table(
+        {"a": [1, 1, 2, 3, 4], "b": [2, 2, 4, 4, None], "c": [10, 10, 20, 30, 40]}
+    )
+    lg_df = LogicalTable.from_arrow(df)
+    res = distinct(lg_df, keys, high_cardinality=high_cardinality)
+    expect = pa.table({"a": [1, 2, 3, 4], "b": [2, 4, 4, None], "c": [10, 20, 30, 40]})
+
+    # Result has no defined order, so need to sort before comparing
+    sort_by = [("a", "ascending"), ("b", "ascending"), ("c", "ascending")]
+    assert_arrow_table_equal(res.to_arrow().sort_by(sort_by), expect.sort_by(sort_by))
+
+
+@pytest.mark.parametrize(
     "arrow_column", get_pyarrow_column_set(["int32", "float32", "int64"])
 )
 def test_column_filter_polars(arrow_column):
@@ -86,3 +108,28 @@ def test_column_filter_polars(arrow_column):
     q = q.filter(pl.col("a") > 0.5)
 
     assert_matches_polars(q)
+
+
+@pytest.mark.parametrize("dtype", ["float64", "int32", "int64"])
+@pytest.mark.parametrize("keys", [["a", "b"], ["a"], ["b"], None])
+def test_polars_distinct(dtype, keys):
+    pl = pytest.importorskip("polars")
+
+    mask = np.random.randint(2, size=10_000, dtype=bool)
+    a = np.random.randint(100, size=10_000).astype(dtype)
+    if dtype == "float64":
+        a[[200, 500, 600]] = np.nan  # see how NaNs are handled.
+
+    b = -a  # Don't deal with duplicates, since we can get any value back
+    b[mask] = 1
+
+    q = pl.DataFrame(
+        {
+            "a": pa.array(a, mask=mask),
+            "b": b,
+        }
+    ).lazy()
+
+    # NOTE(seberg): Descending sort because NaN sorting behaves differently for arrow
+    # (That may need working around in sort; as of 2025-10.)
+    assert_matches_polars(q.unique(keys).sort(["a", "b"], descending=True))

--- a/python/tests/test_tasks.py
+++ b/python/tests/test_tasks.py
@@ -43,7 +43,7 @@ def test_python_launched_tasks():
 
     # Then, we can create the task and provide the task arguments using the
     # exact same order as in the task implementation ("unaryop.cpp").
-    task = runtime.create_auto_task(lib, 14)
+    task = runtime.create_auto_task(lib, 15)
     task.add_scalar_arg("abs", dtype=lg_type.string_type)
     col.add_as_next_task_input(task)
     result = LogicalColumn.empty_like_logical_column(col)


### PR DESCRIPTION
This adds distinct (unique in polars/pandas, but libcudf call is distinct and uses unique for the same operation on pre-sorted arrays).

Arrow seems not to have such a thing, one might be able to do it via structured array columns as well, but groupby and unique are largely the same operation, so I opted to implement it via groupby.

It seemed logical to optimize this for few results (i.e. many dropped columns) by minimizing how much we shuffle, but added an option to not do that.  (If legate-df ever does cardinality estimation via metadata, that could be used for a heuristic here).
