### PR TITLE
BUG: Pass stream to get_element() and others in cudf

### DIFF
--- a/cpp/src/core/column.cu
+++ b/cpp/src/core/column.cu
@@ -311,7 +311,7 @@ std::unique_ptr<cudf::scalar> LogicalColumn::get_cudf_scalar(
   if (col->size() != 1) {
     throw std::invalid_argument("only length 1/scalar columns can be converted to scalar.");
   }
-  return std::move(cudf::get_element(col->view(), 0));
+  return std::move(cudf::get_element(col->view(), 0, stream, mr));
 }
 
 namespace task {
@@ -367,7 +367,7 @@ std::unique_ptr<cudf::scalar> PhysicalColumn::cudf_scalar() const
   if (num_rows() != 1) {
     throw std::invalid_argument("can only convert length one columns to scalar.");
   }
-  return cudf::get_element(column_view(), 0);
+  return cudf::get_element(column_view(), 0, ctx_->stream(), ctx_->mr());
 }
 
 void PhysicalColumn::copy_into(std::unique_ptr<cudf::column> column)

--- a/cpp/src/strings.cu
+++ b/cpp/src/strings.cu
@@ -41,7 +41,7 @@ namespace legate::dataframe::task {
   }
 
   std::unique_ptr<cudf::column> ret;
-  auto cudf_pattern = cudf::string_scalar(pattern);
+  auto cudf_pattern = cudf::string_scalar(pattern, true, ctx.stream(), ctx.mr());
 
   if (match_func == "starts_with") {
     ret = cudf::strings::starts_with(input.column_view(), cudf_pattern, ctx.stream(), ctx.mr());


### PR DESCRIPTION
Maybe `get_element()` didn't support it when this was first added (not sure).

These failures are now very reliable on multi-gpu runs only, though. I audited them and the tests are passing now locally with multi-gpu.
