### PR TITLE
Update RMM includes from `<rmm/mr/device/*>` to `<rmm/mr/*>`

### DIFF
--- a/cpp/include/legate_dataframe/core/allocator.cuh
+++ b/cpp/include/legate_dataframe/core/allocator.cuh
@@ -22,7 +22,7 @@
 
 #include <cudf/column/column_view.hpp>
 #include <cudf/strings/strings_column_view.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
 
 namespace legate {
 namespace dataframe {

--- a/cpp/include/legate_dataframe/core/null_mask.hpp
+++ b/cpp/include/legate_dataframe/core/null_mask.hpp
@@ -22,7 +22,7 @@
 #include <cudf/utilities/bit.hpp>
 #include <rmm/cuda_stream.hpp>
 #include <rmm/device_buffer.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
 #endif
 
 #include <legate.h>

--- a/cpp/include/legate_dataframe/core/ranges.hpp
+++ b/cpp/include/legate_dataframe/core/ranges.hpp
@@ -20,7 +20,7 @@
 #ifdef LEGATE_DATAFRAME_USE_CUDA
 #include <cudf/column/column.hpp>
 #include <rmm/cuda_stream.hpp>
-#include <rmm/mr/device/device_memory_resource.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
 #endif
 
 #include <legate.h>

--- a/cpp/src/core/allocator.cu
+++ b/cpp/src/core/allocator.cu
@@ -17,7 +17,7 @@
 #include <sstream>
 #include <utility>
 
-#include <rmm/mr/device/per_device_resource.hpp>
+#include <rmm/mr/per_device_resource.hpp>
 
 #include <legate_dataframe/core/allocator.cuh>
 #include <legate_dataframe/utils.hpp>


### PR DESCRIPTION
This updates RMM memory resource includes to use the header path `<rmm/mr/*>` instead of `<rmm/mr/device/*>`.

xref: https://github.com/rapidsai/rmm/issues/2141
