### PR TITLE
switch Dockerfile base image from rapidsai/miniforge-cuda to rapidsai/ci-conda

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 ARG CUDA_VERSION="12.9.1"
 ARG PYTHON_VERSION="3.11"
 
-ARG BASE_IMAGE="rapidsai/miniforge-cuda:cuda${CUDA_VERSION}-base-ubuntu24.04-py${PYTHON_VERSION}"
+ARG BASE_IMAGE="rapidsai/ci-conda:cuda${CUDA_VERSION}-ubuntu24.04-py${PYTHON_VERSION}"
 FROM ${BASE_IMAGE}
 RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description

Updates the `Dockerfile` at the repo root to use `rapidsai/ci-conda` (https://hub.docker.com/r/rapidsai/ci-conda).

`rapidsai/miniforge-cuda` will be discontinued after the RAPIDS 26.02 release (https://github.com/rapidsai/ci-imgs/issues/345). `rapidsai/ci-conda` builds on top of it, so it should have everything you need... but may have more than you need. If you find that's the case, you could explore creating your own more minimal image, maybe following the example in https://github.com/rapidsai/docs/pull/734.

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
- [ ] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [x] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
