### PR TITLE
Rename columns to column_names in parquet reader options

### DIFF
--- a/cpp/src/parquet.cu
+++ b/cpp/src/parquet.cu
@@ -85,7 +85,7 @@ namespace legate::dataframe::task {
 
   auto src = cudf::io::source_info(files);
   auto opt = cudf::io::parquet_reader_options::builder(src);
-  opt.columns(columns);
+  opt.column_names(columns);
   opt.row_groups(row_groups);
   // If pandas metadata is read, libcudf may read index columns without this.
   opt.use_pandas_metadata(false);
@@ -158,7 +158,7 @@ namespace legate::dataframe::task {
   // (We could also use a chunked reader on 25.08+.)
   auto src = cudf::io::source_info(files);
   auto opt = cudf::io::parquet_reader_options::builder(src);
-  opt.columns(columns);
+  opt.column_names(columns);
   opt.skip_rows(my_row_offset);
   opt.num_rows(my_nrows);
   // If pandas metadata is read, libcudf may read index columns without this.
@@ -232,7 +232,7 @@ namespace legate::dataframe::task {
 
   auto src = cudf::io::source_info(files);
   auto opt = cudf::io::parquet_reader_options::builder(src);
-  opt.columns(columns);
+  opt.column_names(columns);
   opt.row_groups(row_groups);
 
   auto reader = cudf::io::chunked_parquet_reader(chunksize, chunksize, opt, ctx.stream(), ctx.mr());


### PR DESCRIPTION
## Description
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->
<!-- Read DEVELOPER_GUIDE.md. -->
The `columns` name is deprecated, so lets switch to the new name: `column_names`

Depends on https://github.com/rapidsai/cudf/pull/21113
## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
- [ ] Run `./build.sh test` for local testing, see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#testing).
- [ ] Ensure `pre-commit` checks are passing see [CONTRIBUTING.md](https://github.com/rapidsai/legate-dataframe/blob/main/CONTRIBUTING.md#Pre-commit-hooks).
