### PR TITLE
fix(ci): resolve all zizmor findings and add zizmor pre-commit checks

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,12 +24,13 @@ jobs:
     uses: ./.github/workflows/conda-python-build.yaml
     with:
       script: "ci/build_all.sh"
-    secrets: inherit
   upload-conda:
     needs:
       - conda-python-build
     uses: ./.github/workflows/conda-upload-packages.yaml
-    secrets: inherit
+    secrets:
+      CONDA_LEGATE_TOKEN: ${{ secrets.CONDA_LEGATE_TOKEN }}
+
   docs-build:
     needs:
       - conda-python-build
@@ -38,4 +39,3 @@ jobs:
       script: "ci/build_docs.sh"
       # only deploy docs on tag pushes or when someone manually runs the workflow with "update docs" selected
       deploy: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags')) || (github.event_name == 'workflow_dispatch' && inputs.deploy-docs == true) }}
-    secrets: inherit

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,7 @@
 name: build
-
 concurrency:
   group: ci-on-${{ github.event_name }}-from-${{ github.ref_name }}
   cancel-in-progress: true
-
 on:
   # run on pushes to certain branches
   push:
@@ -20,7 +18,7 @@ on:
         description: 'Update the docs site?'
         required: true
         type: boolean
-
+permissions: {}
 jobs:
   conda-python-build:
     uses: ./.github/workflows/conda-python-build.yaml

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -56,7 +56,20 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: build
-        run: "${{ inputs.script }}"
+        env:
+          SCRIPT: ${{ inputs.script }}
+        run: |
+          script_path="$(realpath "$SCRIPT")"
+          ci_dir="$(realpath ci)"
+
+          # Use `realpath` to expand out both the script path and the ci path and compare to make sure
+          # that user isn't giving a relative path to a file outside of `ci/`
+          if [[ "$script_path" != "$ci_dir"/*.sh ]]; then
+            echo "::error::Invalid script path '$SCRIPT'. Expected an existing ci/*.sh script inside the checkout"
+            exit 1
+          fi
+
+          bash "$script_path"
       - name: upload
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -1,9 +1,7 @@
 name: conda-python-build
-
 concurrency:
   group: conda-python-build-on-${{ github.event_name }}-from-${{ github.ref_name }}
   cancel-in-progress: true
-
 on:
   # run only when called by other workflows
   workflow_call:
@@ -12,12 +10,10 @@ on:
         required: true
         type: string
         description: "relative path to a script that builds conda packages"
-
 # override default permissions
 permissions:
   # needed to auth with AWS for sccache
   id-token: write
-
 env:
   # CUDA architectures to build for
   CUDAARCHS: "all-major"
@@ -26,9 +22,7 @@ env:
   GH_TOKEN: ${{ github.token }}
   # where conda-python-build puts files it creates
   RAPIDS_CONDA_BLD_OUTPUT_DIR: /tmp/conda-bld-output
-
 jobs:
-
   build:
     strategy:
       fail-fast: false

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -54,6 +54,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: build
         run: "${{ inputs.script }}"
       - name: upload

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -52,18 +52,18 @@ jobs:
     container:
       image: "rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-ubuntu24.04-py${{ matrix.PY_VER }}"
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 14400 # 4h
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: build
         run: "${{ inputs.script }}"
       - name: upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: legate-dataframe-conda-cuda${{ matrix.CUDA_VER }}-${{ matrix.ARCH }}-py${{ matrix.PY_VER }}
           path: ${{ env.RAPIDS_CONDA_BLD_OUTPUT_DIR }}

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -8,6 +8,9 @@
 on:
   # run only when called by other workflows
   workflow_call:
+    secrets:
+      CONDA_LEGATE_TOKEN:
+        required: false
 env:
   # where jobs that download conda packages store the local channel
   RAPIDS_LOCAL_CONDA_CHANNEL: /tmp/local-conda-packages

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -19,11 +19,11 @@ jobs:
     container:
       image: rapidsai/ci-conda:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: download conda packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           # omitting 'name' here means "download all artifacts from this run"... useful to
           # avoid having to list the matrix of CUDA / Python versions here

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -19,7 +19,7 @@ jobs:
   upload:
     runs-on: linux-amd64-cpu4
     container:
-      image: rapidsai/ci-conda:latest
+      image: rapidsai/ci-conda:latest  # zizmor: ignore[unpinned-images]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: download conda packages
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -8,11 +8,10 @@
 on:
   # run only when called by other workflows
   workflow_call:
-
 env:
   # where jobs that download conda packages store the local channel
   RAPIDS_LOCAL_CONDA_CHANNEL: /tmp/local-conda-packages
-
+permissions: {}
 jobs:
   upload:
     runs-on: linux-amd64-cpu4

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -46,7 +46,20 @@ jobs:
           repository: ${{ github.repository }}
           run-id: ${{ github.run_id }}
       - name: build docs
-        run: "${{ inputs.script }}"
+        env:
+          SCRIPT: ${{ inputs.script }}
+        run: |
+          script_path="$(realpath "$SCRIPT")"
+          ci_dir="$(realpath ci)"
+
+          # Use `realpath` to expand out both the script path and the ci path and compare to make sure
+          # that user isn't giving a relative path to a file outside of `ci/`
+          if [[ "$script_path" != "$ci_dir"/*.sh ]]; then
+            echo "::error::Invalid script path '$SCRIPT'. Expected an existing ci/*.sh script inside the checkout"
+            exit 1
+          fi
+
+          bash "$script_path"
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/build/html

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -37,11 +37,11 @@ jobs:
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: download conda packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: legate-dataframe-conda-cuda${{ matrix.CUDA_VER }}-${{ matrix.ARCH }}-py${{ matrix.PY_VER }}
           path: ${{ env.RAPIDS_LOCAL_CONDA_CHANNEL }}
@@ -50,7 +50,7 @@ jobs:
           run-id: ${{ github.run_id }}
       - name: build docs
         run: "${{ inputs.script }}"
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/build/html
 
@@ -73,4 +73,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -36,6 +36,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: download conda packages
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/docs-build.yaml
+++ b/.github/workflows/docs-build.yaml
@@ -1,9 +1,7 @@
 name: docs-build
-
 concurrency:
   group: docs-build-on-${{ github.event_name }}-from-${{ github.ref_name }}
   cancel-in-progress: true
-
 on:
   # run only when called by other workflows
   workflow_call:
@@ -17,13 +15,11 @@ on:
         required: true
         type: string
         description: "relative path to a script that builds conda packages"
-
 env:
   # where jobs that download conda packages store the local channel
   RAPIDS_LOCAL_CONDA_CHANNEL: /tmp/local-conda-packages
-
+permissions: {}
 jobs:
-
   build:
     strategy:
       matrix:
@@ -53,22 +49,18 @@ jobs:
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/build/html
-
   deploy:
     needs:
       - build
     if: inputs.deploy
-
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
-      pages: write      # to deploy to Pages
-      id-token: write   # to verify the deployment originates from an appropriate source
-
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
     # Deploy to the github-pages environment
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-
     runs-on: ubuntu-latest
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,6 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
       - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   conda-python-build:
     needs:
@@ -37,7 +39,6 @@ jobs:
     uses: ./.github/workflows/conda-python-build.yaml
     with:
       script: "ci/build_all.sh"
-    secrets: inherit
   conda-python-cpu-tests:
     needs:
       - pre-commit
@@ -59,6 +60,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: download conda packages
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -101,6 +103,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: download conda packages
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
@@ -119,4 +122,3 @@ jobs:
     with:
       script: "ci/build_docs.sh"
       deploy: false
-    secrets: inherit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,8 +28,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: pre-commit/action@v3.0.1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
 
   conda-python-build:
     needs:
@@ -58,11 +58,11 @@ jobs:
     container:
       image: "rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-ubuntu24.04-py${{ matrix.PY_VER }}"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: download conda packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: legate-dataframe-conda-cuda${{ matrix.CUDA_VER }}-${{ matrix.ARCH }}-py${{ matrix.PY_VER }}
           path: ${{ env.RAPIDS_LOCAL_CONDA_CHANNEL }}
@@ -100,11 +100,11 @@ jobs:
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: download conda packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: legate-dataframe-conda-cuda${{ matrix.CUDA_VER }}-${{ matrix.ARCH }}-py${{ matrix.PY_VER }}
           path: ${{ env.RAPIDS_LOCAL_CONDA_CHANNEL }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,20 +1,16 @@
 name: pr
-
 concurrency:
   group: ci-on-${{ github.event_name }}-from-${{ github.ref_name }}
   cancel-in-progress: true
-
 on:
   push:
     branches:
       - "pull-request/[0-9]+"
-
 env:
   # where jobs that download conda packages store the local channel
   RAPIDS_LOCAL_CONDA_CHANNEL: /tmp/local-conda-packages
-
+permissions: {}
 jobs:
-
   # group together all jobs that must pass for a PR to be merged
   # (for use by branch protections)
   pr-builder:
@@ -24,13 +20,17 @@ jobs:
       - conda-python-cpu-tests
       - conda-python-gpu-tests
     uses: rapidsai/shared-workflows/.github/workflows/pr-builder.yaml@branch-25.08
-
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      packages: read
+      pull-requests: read
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
   conda-python-build:
     needs:
       - pre-commit
@@ -38,7 +38,6 @@ jobs:
     with:
       script: "ci/build_all.sh"
     secrets: inherit
-
   conda-python-cpu-tests:
     needs:
       - pre-commit
@@ -72,7 +71,6 @@ jobs:
       - name: test python and C++ interface
         run: |
           ci/test_cpu.sh
-
   conda-python-gpu-tests:
     needs:
       - pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,6 +87,10 @@ repos:
     hooks:
         - id: rapids-dependency-file-generator
           args: ["--clean"]
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: v1.24.1
+    hooks:
+      - id: zizmor
 
 default_language_version:
       python: python3

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,9 @@
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # We require SHA-pinning for all workflows and actions _except_ for those from
+        # rapidsai/shared-workflows and rapidsai/shared-actions
+        "rapidsai/shared-workflows/*": any
+        "rapidsai/shared-actions/*": any
+        "*": hash-pin


### PR DESCRIPTION

Similar to upstream changes in `shared-workflows`, this PR cleans up and annotates all of the workflows and adds the `zizmor` linter to make sure changes are checked.

Part of https://github.com/rapidsai/build-planning/issues/275