### PR TITLE
Add SECURITY.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# default codeowners (overridden by more specific matches below)
+* @rapidsai/legate-dataframe-write
+
+# Ops code owners
+/SECURITY.md             @rapidsai/ops-codeowners

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security
+
+## Reporting Security Issues
+
+> [!WARNING]
+> Do not report security vulnerabilities through public GitHub issues!
+
+Instead, please submit a private vulnerability report, see below.
+
+## Reporting a Vulnerability
+
+1. **NVIDIA Vulnerability Disclosure Program (preferred)**
+   Submit through the NVIDIA Product Security Incident Response Team (PSIRT) web form (<https://www.nvidia.com/en-us/security/report-vulnerability/>)
+   This is the fastest path to triage and tracking.
+
+2. **Email NVIDIA PSIRT**
+   `psirt@nvidia.com` — encrypt sensitive reports with the
+   [NVIDIA PSIRT PGP key](https://www.nvidia.com/en-us/security/pgp-key).
+
+3. **GitHub Private Vulnerability Reporting**
+   Use the **Security and quality** tab on this repository → *Report a vulnerability*.
+
+## Report Details
+
+We prefer all communications to be in English.
+
+Reports should include the following:
+
+* reproducible example showing how the vulnerability can be exploited
+* statement about the impact (including affected versions)
+
+And we'd appreciate if they also include:
+
+* statement about whether you are interested in implementing the fix yourself
+
+## Disclosure Policy
+
+NVIDIA PSIRT will acknowledge receipt and coordinate triage, fix development, and coordinated disclosure.
+
+More on NVIDIA's response process: <https://www.nvidia.com/en-us/security/psirt-policies/>.


### PR DESCRIPTION
## Description

Contributes to https://github.com/rapidsai/build-planning/issues/281

* adds a `SECURITY.md` describing how to report security vulnerabilities

## Notes for Reviewers

### Why not just set this org-wide?

An org-wide default is set at https://github.com/rapidsai/.github/blob/main/SECURITY.md, but adding an actual file in each repo offers a few benefits:

* ensures security policy travels with the repo to forks, clones, mirrors, etc.
* allows per-repo governance over the security policy (via PR review, CODEOWNERS, etc.)

### This can be admin-merged

I'll stop CI intentionally after `pre-commit` runs, to save CI time and resources.
